### PR TITLE
Unix: Fix binary permissions

### DIFF
--- a/StabilityMatrix.Avalonia/Assets.cs
+++ b/StabilityMatrix.Avalonia/Assets.cs
@@ -25,6 +25,11 @@ internal static class Assets
     public static AvaloniaResource LicensesJson => new(
         "avares://StabilityMatrix.Avalonia/Assets/licenses.json");
 
+    private const UnixFileMode unix755 = UnixFileMode.UserRead | UnixFileMode.UserWrite |
+        UnixFileMode.UserExecute | UnixFileMode.GroupRead |
+        UnixFileMode.GroupExecute | UnixFileMode.OtherRead |
+        UnixFileMode.OtherExecute;
+
     [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("linux")]
     [SupportedOSPlatform("macos")]
@@ -32,9 +37,9 @@ internal static class Assets
         (PlatformKind.Windows,
             new AvaloniaResource("avares://StabilityMatrix.Avalonia/Assets/win-x64/7za.exe")),
         (PlatformKind.Linux | PlatformKind.X64,
-            new AvaloniaResource("avares://StabilityMatrix.Avalonia/Assets/linux-x64/7zzs", (UnixFileMode) 0777)),
+            new AvaloniaResource("avares://StabilityMatrix.Avalonia/Assets/linux-x64/7zzs", unix755)),
         (PlatformKind.MacOS | PlatformKind.Arm,
-            new AvaloniaResource("avares://StabilityMatrix.Avalonia/Assets/macos-arm64/7zz", (UnixFileMode) 0x777)));
+            new AvaloniaResource("avares://StabilityMatrix.Avalonia/Assets/macos-arm64/7zz", unix755)));
     
     [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("linux")]

--- a/StabilityMatrix.Avalonia/Program.cs
+++ b/StabilityMatrix.Avalonia/Program.cs
@@ -107,7 +107,11 @@ public class Program
                     // Ensure permissions are set for unix
                     if (Compat.IsUnix)
                     {
-                        File.SetUnixFileMode(targetExe, (UnixFileMode) 0x755);
+                        File.SetUnixFileMode(targetExe, // 0755
+                            UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                            UnixFileMode.UserExecute | UnixFileMode.GroupRead |
+                            UnixFileMode.GroupExecute | UnixFileMode.OtherRead |
+                            UnixFileMode.OtherExecute);
                     }
                     
                     // Start the new app

--- a/StabilityMatrix.Avalonia/ViewModels/Dialogs/UpdateViewModel.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/Dialogs/UpdateViewModel.cs
@@ -97,7 +97,11 @@ public partial class UpdateViewModel : ContentDialogViewModelBase
         // On unix, we need to set the executable bit
         if (Compat.IsUnix)
         {
-            File.SetUnixFileMode(UpdateHelper.ExecutablePath, (UnixFileMode) 0x755);
+            File.SetUnixFileMode(UpdateHelper.ExecutablePath, // 0755
+                UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                UnixFileMode.UserExecute | UnixFileMode.GroupRead |
+                UnixFileMode.GroupExecute | UnixFileMode.OtherRead |
+                UnixFileMode.OtherExecute);
         }
         
         UpdateText = "Update complete. Restarting Stability Matrix in 3 seconds...";


### PR DESCRIPTION
The AppImage release of v2.3.3 errors while installing A1111 with `An error occurred trying to start process '/home/user/Applications/Data/Assets/7zzs' with working directory '/home/user/Applications'. Permission denied`

The permissions applied were `-r----x--t`. I found a typo in the permissions, but also the `UnixFileMode` (https://learn.microsoft.com/en-us/dotnet/api/system.io.unixfilemode) is an enum which doesn't cast from typical values like 0777.

I also noticed the permissions were overly permissive. This change also prevents `group` and `other` writes (0755).

---

https://github.com/LykosAI/StabilityMatrix/blob/14743dbf394a5b092287294dc70fd3b9b761071f/StabilityMatrix.Avalonia/ViewModels/Dialogs/UpdateViewModel.cs#L100 and https://github.com/LykosAI/StabilityMatrix/blob/14743dbf394a5b092287294dc70fd3b9b761071f/StabilityMatrix.Avalonia/Program.cs#L110 also have the same issue, so this PR addresses them