### PR TITLE
Add .txt sidecar support to output browser

### DIFF
--- a/StabilityMatrix.Avalonia/ViewModels/OutputsPageViewModel.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/OutputsPageViewModel.cs
@@ -28,6 +28,7 @@ using StabilityMatrix.Avalonia.ViewModels.Base;
 using StabilityMatrix.Avalonia.ViewModels.Dialogs;
 using StabilityMatrix.Avalonia.ViewModels.OutputsPage;
 using StabilityMatrix.Core.Attributes;
+using StabilityMatrix.Core.Exceptions;
 using StabilityMatrix.Core.Extensions;
 using StabilityMatrix.Core.Helper;
 using StabilityMatrix.Core.Helper.Factory;
@@ -323,6 +324,12 @@ public partial class OutputsPageViewModel : PageViewModelBase
         {
             return;
         }
+        //Attempt to remove .txt sidecar if it exists
+        var sideCar = new FilePath(Path.ChangeExtension(imageFile, ".txt"));
+        if (File.Exists(sideCar))
+        {
+            await notificationService.TryAsync(sideCar.DeleteAsync());
+        }
 
         OutputsCache.Remove(item.ImageFile);
 
@@ -388,6 +395,14 @@ public partial class OutputsPageViewModel : PageViewModelBase
             {
                 continue;
             }
+
+            //Attempt to remove .txt sidecar if it exists
+            var sideCar = new FilePath(Path.ChangeExtension(imageFile, ".txt"));
+            if (File.Exists(sideCar))
+            {
+                await notificationService.TryAsync(sideCar.DeleteAsync());
+            }
+
             OutputsCache.Remove(output.ImageFile);
 
             // Invalidate cache
@@ -485,6 +500,14 @@ public partial class OutputsPageViewModel : PageViewModelBase
                     }
 
                     await file.MoveToWithIncrementAsync(newPath);
+
+                    var sideCar = new FilePath(Path.ChangeExtension(file, ".txt"));
+                    //If a .txt sidecar file exists, and the image was moved successfully, try to move the sidecar along with the image
+                    if (File.Exists(newPath) && File.Exists(sideCar))
+                    {
+                        var newSidecar = new FilePath(Path.ChangeExtension(newPath, ".txt"));
+                        await sideCar.MoveToWithIncrementAsync(newSidecar);
+                    }
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
(As reported in #248)

Output Browser - "ConsolidateImages" - Check for existence of .txt file sidecar with same filename as image, and attempts to move alongside image if image move is successful 

Output Browser - "DeleteImage/DeleteAllSelected" - Check for existence of .txt file sidecar with same filename as image(s), and attempts to move alongside image(s) if image delete is successful
