### PR TITLE
fix: add check if AvailableCommits contains anything

### DIFF
--- a/StabilityMatrix.Avalonia/ViewModels/Dialogs/InstallerViewModel.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/Dialogs/InstallerViewModel.cs
@@ -90,11 +90,7 @@ public partial class InstallerViewModel : ContentDialogViewModelBase
 
     // Version types (release or commit)
     [ObservableProperty]
-    [NotifyPropertyChangedFor(
-        nameof(ReleaseLabelText),
-        nameof(IsReleaseMode),
-        nameof(SelectedVersion)
-    )]
+    [NotifyPropertyChangedFor(nameof(ReleaseLabelText), nameof(IsReleaseMode), nameof(SelectedVersion))]
     private PackageVersionType selectedVersionType = PackageVersionType.Commit;
 
     [ObservableProperty]
@@ -106,22 +102,16 @@ public partial class InstallerViewModel : ContentDialogViewModelBase
     [NotifyPropertyChangedFor(nameof(CanInstall))]
     private bool isLoading;
 
-    public string ReleaseLabelText =>
-        IsReleaseMode ? Resources.Label_Version : Resources.Label_Branch;
+    public string ReleaseLabelText => IsReleaseMode ? Resources.Label_Version : Resources.Label_Branch;
     public bool IsReleaseMode
     {
         get => SelectedVersionType == PackageVersionType.GithubRelease;
-        set =>
-            SelectedVersionType = value
-                ? PackageVersionType.GithubRelease
-                : PackageVersionType.Commit;
+        set => SelectedVersionType = value ? PackageVersionType.GithubRelease : PackageVersionType.Commit;
     }
-    public bool IsReleaseModeAvailable =>
-        AvailableVersionTypes.HasFlag(PackageVersionType.GithubRelease);
+    public bool IsReleaseModeAvailable => AvailableVersionTypes.HasFlag(PackageVersionType.GithubRelease);
     public bool ShowTorchVersionOptions => SelectedTorchVersion != TorchVersion.None;
 
-    public bool CanInstall =>
-        !string.IsNullOrWhiteSpace(InstallName) && !ShowDuplicateWarning && !IsLoading;
+    public bool CanInstall => !string.IsNullOrWhiteSpace(InstallName) && !ShowDuplicateWarning && !IsLoading;
 
     public IEnumerable<IPackageStep> Steps { get; set; }
 
@@ -254,10 +244,8 @@ public partial class InstallerViewModel : ContentDialogViewModelBase
         if (IsReleaseMode)
         {
             downloadOptions.VersionTag =
-                SelectedVersion?.TagName
-                ?? throw new NullReferenceException("Selected version is null");
-            downloadOptions.IsLatest =
-                AvailableVersions?.First().TagName == downloadOptions.VersionTag;
+                SelectedVersion?.TagName ?? throw new NullReferenceException("Selected version is null");
+            downloadOptions.IsLatest = AvailableVersions?.First().TagName == downloadOptions.VersionTag;
             downloadOptions.IsPrerelease = SelectedVersion.IsPrerelease;
 
             installedVersion.InstalledReleaseVersion = downloadOptions.VersionTag;
@@ -268,21 +256,15 @@ public partial class InstallerViewModel : ContentDialogViewModelBase
             downloadOptions.CommitHash =
                 SelectedCommit?.Sha ?? throw new NullReferenceException("Selected commit is null");
             downloadOptions.BranchName =
-                SelectedVersion?.TagName
-                ?? throw new NullReferenceException("Selected version is null");
+                SelectedVersion?.TagName ?? throw new NullReferenceException("Selected version is null");
             downloadOptions.IsLatest = AvailableCommits?.First().Sha == SelectedCommit.Sha;
 
             installedVersion.InstalledBranch =
-                SelectedVersion?.TagName
-                ?? throw new NullReferenceException("Selected version is null");
+                SelectedVersion?.TagName ?? throw new NullReferenceException("Selected version is null");
             installedVersion.InstalledCommitSha = downloadOptions.CommitHash;
         }
 
-        var downloadStep = new DownloadPackageVersionStep(
-            SelectedPackage,
-            installLocation,
-            downloadOptions
-        );
+        var downloadStep = new DownloadPackageVersionStep(SelectedPackage, installLocation, downloadOptions);
         var installStep = new InstallPackageStep(
             SelectedPackage,
             SelectedTorchVersion,
@@ -351,9 +333,7 @@ public partial class InstallerViewModel : ContentDialogViewModelBase
         else
         {
             // First try to find the package-defined main branch
-            var version = AvailableVersions.FirstOrDefault(
-                x => x.TagName == SelectedPackage.MainBranch
-            );
+            var version = AvailableVersions.FirstOrDefault(x => x.TagName == SelectedPackage.MainBranch);
             // If not found, try main
             version ??= AvailableVersions.FirstOrDefault(x => x.TagName == "main");
 
@@ -406,8 +386,8 @@ public partial class InstallerViewModel : ContentDialogViewModelBase
         if (SelectedPackage is null || Design.IsDesignMode)
             return;
 
-        Dispatcher.UIThread
-            .InvokeAsync(async () =>
+        Dispatcher
+            .UIThread.InvokeAsync(async () =>
             {
                 logger.LogDebug($"Release mode: {IsReleaseMode}");
                 var versionOptions = await SelectedPackage.GetAllVersionOptions();
@@ -425,9 +405,7 @@ public partial class InstallerViewModel : ContentDialogViewModelBase
 
                 if (!IsReleaseMode)
                 {
-                    var commits = (
-                        await SelectedPackage.GetAllCommits(SelectedVersion.TagName)
-                    )?.ToList();
+                    var commits = (await SelectedPackage.GetAllCommits(SelectedVersion.TagName))?.ToList();
                     if (commits is null || commits.Count == 0)
                         return;
 
@@ -495,7 +473,11 @@ public partial class InstallerViewModel : ContentDialogViewModelBase
                         Dispatcher.UIThread.Post(() =>
                         {
                             AvailableCommits = new ObservableCollection<GitCommit>(hashes);
-                            SelectedCommit = AvailableCommits[0];
+
+                            if (AvailableCommits.Count > 0)
+                            {
+                                SelectedCommit = AvailableCommits[0];
+                            }
                         });
                     }
                     catch (Exception e)


### PR DESCRIPTION
This PR fixes an issue, where an exception would be thrown, if the `AvailableCommits` enumerable did not contain any changes.