### PR TITLE
Fix pytorch version used in invokeai

### DIFF
--- a/StabilityMatrix.Core/Models/Packages/InvokeAI.cs
+++ b/StabilityMatrix.Core/Models/Packages/InvokeAI.cs
@@ -191,9 +191,9 @@ public class InvokeAI : BaseGitPackage
                 await venvRunner
                     .PipInstall(
                         new PipInstallArgs(args.Any() ? args.ToArray() : Array.Empty<Argument>())
-                            .WithTorch("==2.1.0")
-                            .WithTorchVision("==0.16.0")
-                            .WithXFormers("==0.0.22post7")
+                            .WithTorch("==2.1.2")
+                            .WithTorchVision("==0.16.2")
+                            .WithXFormers("==0.0.23post1")
                             .WithTorchExtraIndex("cu121"),
                         onConsoleOutput
                     )


### PR DESCRIPTION
InvokeAI uses [torch 2.1.2](https://github.com/invoke-ai/InvokeAI/blob/968fb655a493223bb22da42769e226743a46c50b/installer/lib/installer.py#L247) while Stability Matrix was using torch 2.1.0 for InvokeAI.