### PR TITLE
Add a LyCORIS folder to path_loras in Fooocus config.

### DIFF
--- a/StabilityMatrix.Core/Models/Packages/Fooocus.cs
+++ b/StabilityMatrix.Core/Models/Packages/Fooocus.cs
@@ -312,7 +312,11 @@ public class Fooocus(
         }
 
         fooocusConfig["path_checkpoints"] = Path.Combine(settingsManager.ModelsDirectory, "StableDiffusion");
-        fooocusConfig["path_loras"] = Path.Combine(settingsManager.ModelsDirectory, "Lora");
+        fooocusConfig["path_loras"] = new JsonArray
+        {
+            Path.Combine(settingsManager.ModelsDirectory, "Lora"),
+            Path.Combine(settingsManager.ModelsDirectory, "LyCORIS")
+        };
         fooocusConfig["path_embeddings"] = Path.Combine(settingsManager.ModelsDirectory, "TextualInversion");
         fooocusConfig["path_vae_approx"] = Path.Combine(settingsManager.ModelsDirectory, "ApproxVAE");
         fooocusConfig["path_upscale_models"] = Path.Combine(settingsManager.ModelsDirectory, "ESRGAN");


### PR DESCRIPTION
- Fooocus can handle LyCORIS just like Lora.
- The Fooocus config.txt file allows specification of multiple folders for both Lora and LyCORIS in path_loras.
- In StabilityMatrix, separate folders are used for LyCORIS and Lora for model sharing.
- Each time Fooocus is invoked from StabilityMatrix, the config.txt file is overwritten, limiting the path_loras to only include the Lora folder.

These limitations lead to unnecessary constraints.
This PR adds a LyCORIS folder to path_loras, in addition to the existing Lora folder.