### PR TITLE
Quickly adding unet path for ComfyUI

### DIFF
--- a/StabilityMatrix.Core/Models/Packages/ComfyUI.cs
+++ b/StabilityMatrix.Core/Models/Packages/ComfyUI.cs
@@ -374,6 +374,7 @@ public class ComfyUI(
                 Path.Combine(modelsDir, "InvokeIpAdaptersXl")
             );
             nodeValue.Children["prompt_expansion"] = Path.Combine(modelsDir, "PromptExpansion");
+            nodeValue.Children["unet"] = Path.Combine(modelsDir, "unet");
         }
         else
         {

--- a/StabilityMatrix.Core/Models/Packages/ComfyUI.cs
+++ b/StabilityMatrix.Core/Models/Packages/ComfyUI.cs
@@ -67,7 +67,8 @@ public class ComfyUI(
             [SharedFolderType.InvokeIpAdapters15] = new[] { "models/ipadapter/sd15" },
             [SharedFolderType.InvokeIpAdaptersXl] = new[] { "models/ipadapter/sdxl" },
             [SharedFolderType.T2IAdapter] = new[] { "models/controlnet/T2IAdapter" },
-            [SharedFolderType.PromptExpansion] = new[] { "models/prompt_expansion" }
+            [SharedFolderType.PromptExpansion] = new[] { "models/prompt_expansion" },
+            [SharedFolderType.Unet] = new[] { "models/unet" }
         };
 
     public override Dictionary<SharedOutputType, IReadOnlyList<string>>? SharedOutputFolders =>

--- a/StabilityMatrix.Core/Models/Packages/ComfyUI.cs
+++ b/StabilityMatrix.Core/Models/Packages/ComfyUI.cs
@@ -412,7 +412,8 @@ public class ComfyUI(
                             Path.Combine(modelsDir, "InvokeIpAdaptersXl")
                         )
                     },
-                    { "prompt_expansion", Path.Combine(modelsDir, "PromptExpansion") }
+                    { "prompt_expansion", Path.Combine(modelsDir, "PromptExpansion") },
+                    { "unet", Path.Combine(modelsDir, "unet") },
                 }
             );
         }

--- a/StabilityMatrix.Core/Models/SharedFolderType.cs
+++ b/StabilityMatrix.Core/Models/SharedFolderType.cs
@@ -43,5 +43,6 @@ public enum SharedFolderType
     InvokeClipVision = 1 << 26,
     SVD = 1 << 27,
 
-    PromptExpansion = 1 << 30
+    PromptExpansion = 1 << 30,
+    Unet = 1 << 31
 }


### PR DESCRIPTION
Threw this together quickly to try to resolve #831 (and #805 among others) - We're just missing a mapping in the config, and it looks like this should add it.