### PR TITLE
Improve Japanese translations

### DIFF
--- a/StabilityMatrix.Avalonia/Languages/Resources.ja-JP.resx
+++ b/StabilityMatrix.Avalonia/Languages/Resources.ja-JP.resx
@@ -171,14 +171,14 @@
     <comment>checkpoint / embedding / LoRA are often used in the same way as the above words on Japanese information websites, so it is easier to understand them without translation.</comment>
   </data>
   <data name="Label_Emphasis" xml:space="preserve">
-    <value>プロンプトの強調</value>
+    <value>プロンプトを強調</value>
     <comment>The word has not been translated because it is not possible to guess what part of the UI it is used in. It is a little difficult to translate the word into Japanese, so I want to be careful not to change the meaning of the word.</comment>
   </data>
   <data name="Label_Deemphasis" xml:space="preserve">
-    <value>プロンプトの縮小</value>
+    <value>プロンプトを弱める</value>
   </data>
   <data name="Label_EmbeddingsOrTextualInversion" xml:space="preserve">
-    <value>Emebeddings / Textual Inversion</value>
+    <value>Embeddings / Textual Inversion</value>
   </data>
   <data name="Label_NetworksLoraOrLycoris" xml:space="preserve">
     <value>Networks (Lora / LyCORIS)</value>
@@ -205,10 +205,10 @@
     <value>Denoising Strength</value>
   </data>
   <data name="Label_Width" xml:space="preserve">
-    <value>幅</value>
+    <value>横</value>
   </data>
   <data name="Label_Height" xml:space="preserve">
-    <value>高</value>
+    <value>縦</value>
   </data>
   <data name="Label_Refiner" xml:space="preserve">
     <value>Refiner</value>
@@ -309,7 +309,7 @@
     <value>Modelの説明</value>
   </data>
   <data name="Label_NewVersionAvailable" xml:space="preserve">
-    <value>Stability Matrixを最新版に更新中！</value>
+    <value>新しいバージョンのStability Matrixが利用可能です！</value>
   </data>
   <data name="Label_ImportLatest" xml:space="preserve">
     <value>最新版DL</value>
@@ -410,7 +410,7 @@
     <value>使用許諾契約書</value>
   </data>
   <data name="Label_FindConnectedMetadata" xml:space="preserve">
-    <value>メタデータが見つかりました</value>
+    <value>メタデータを探す</value>
   </data>
   <data name="Label_ShowModelImages" xml:space="preserve">
     <value>モデルの見出し画像を表示</value>
@@ -620,7 +620,7 @@
     <value>パッケージのアンインストール</value>
   </data>
   <data name="Text_SomeFilesCouldNotBeDeleted" xml:space="preserve">
-    <value>一部のファイルを削除できませんでした。該当のディレクトリ内にあるファイルで開いていたものを全て閉じて、もう一度試してください。</value>
+    <value>一部のファイルを削除できませんでした。該当のフォルダの開いているファイルを全て閉じてから、もう一度試してください。</value>
   </data>
   <data name="Label_InvalidPackageType" xml:space="preserve">
     <value>無効なパッケージタイプ</value>
@@ -759,7 +759,7 @@
     <value>よろしいですか？</value>
   </data>
   <data name="Label_ConsolidateExplanation" xml:space="preserve">
-    <value>これにより、選択したパッケージから生成されたすべてのイメージが、共有出力フォルダの Consolidated ディレクトリに移動します。この操作は元に戻せません。</value>
+    <value>これにより、選択したパッケージから生成されたすべてのイメージが、共有出力フォルダの Consolidated フォルダに移動します。この操作は元に戻せません。</value>
   </data>
   <data name="Action_Refresh" xml:space="preserve">
     <value>更新</value>
@@ -1042,22 +1042,22 @@
     <value>いい感じ！</value>
   </data>
   <data name="Label_NvidiaGpuRecommended" xml:space="preserve">
-    <value>快適な利用にはCUDA対応GPUを推奨します。それ以外だと一部のパッケージが動作しなかったり、動くけど遅い場合があります。</value>
+    <value>快適な利用にはCUDA対応GPUを推奨します。非対応の場合一部のパッケージが動作しない場合や、動作が遅くなる場合があります。</value>
   </data>
   <data name="Label_Checkpoints" xml:space="preserve">
     <value>Checkpoints</value>
   </data>
   <data name="Label_ModelBrowser" xml:space="preserve">
-    <value>Model Brouser</value>
+    <value>Model Browser</value>
   </data>
   <data name="TeachingTip_WebUiButtonMoved" xml:space="preserve">
     <value>&apos;Web UIを開く&apos;ボタンがコマンドバーに移動しました</value>
   </data>
   <data name="Label_AnotherInstanceAlreadyRunning" xml:space="preserve">
-    <value>Stability Matrixは既に立ち上がってます。それを終了させてから、もう一度起動してください。</value>
+    <value>Stability Matrixは既に起動中です。終了してから、もう一度起動してください。</value>
   </data>
   <data name="Label_StabilityMatrixAlreadyRunning" xml:space="preserve">
-    <value>Stability Matrixは既に立ち上がってます</value>
+    <value>Stability Matrixは既に起動中です</value>
   </data>
   <data name="Label_WorkflowDeletedSuccessfully" xml:space="preserve">
     <value>{0} 個削除しました</value>
@@ -1132,7 +1132,7 @@
     <value>{0}のバージョンが更新されました。</value>
   </data>
   <data name="Action_CopyAsBitmap" xml:space="preserve">
-    <value>bitmapにコピー</value>
+    <value>Bitmapとしてコピー</value>
   </data>
   <data name="Label_DisableUpdateCheck" xml:space="preserve">
     <value>アップデートチェックを無効にする</value>

--- a/StabilityMatrix.Avalonia/Languages/Resources.ja-JP.resx
+++ b/StabilityMatrix.Avalonia/Languages/Resources.ja-JP.resx
@@ -146,8 +146,7 @@
     <value>再起動が必要です</value>
   </data>
   <data name="Label_UnknownPackage" xml:space="preserve">
-    <value>不明なパッケージ
-</value>
+    <value>不明なパッケージ</value>
   </data>
   <data name="Action_Import" xml:space="preserve">
     <value>インポート</value>
@@ -165,8 +164,7 @@
     <value>Releases</value>
   </data>
   <data name="Label_Branches" xml:space="preserve">
-    <value>ブランチ
-</value>
+    <value>ブランチ</value>
   </data>
   <data name="Label_DragAndDropCheckpointsHereToImport" xml:space="preserve">
     <value>インポートしたいcheckpointをここにドラッグ＆ドロップ</value>
@@ -739,6 +737,18 @@
   <data name="Label_OneImageSelected" xml:space="preserve">
     <value>1枚の画像を選択</value>
   </data>
+    <data name="Label_Preprocessor" xml:space="preserve">
+    <value>プリプロセッサ</value>
+  </data>
+  <data name="Label_Strength" xml:space="preserve">
+    <value>強度</value>
+  </data>
+  <data name="Label_ControlWeight" xml:space="preserve">
+    <value>Control Weight</value>
+  </data>
+  <data name="Label_ControlSteps" xml:space="preserve">
+    <value>Control Steps</value>
+  </data>
   <data name="Label_PythonPackages" xml:space="preserve">
     <value>Pythonパッケージ</value>
   </data>
@@ -793,18 +803,6 @@
   <data name="Label_Accounts" xml:space="preserve">
     <value>アカウント</value>
   </data>
-  <data name="Label_Preprocessor" xml:space="preserve">
-    <value>プリプロセッサ</value>
-  </data>
-  <data name="Label_Strength" xml:space="preserve">
-    <value>強度</value>
-  </data>
-  <data name="Label_ControlWeight" xml:space="preserve">
-    <value>Control Weight</value>
-  </data>
-  <data name="Label_ControlSteps" xml:space="preserve">
-    <value>Control Steps</value>
-  </data>
   <data name="Label_CivitAiLoginRequired" xml:space="preserve">
     <value>ダウンロードにはCivitAIのログインが必要です。SettingからAPIキーを入力してください。</value>
   </data>
@@ -845,16 +843,13 @@
     <value>Metadataをアップデートする</value>
   </data>
   <data name="Label_General" xml:space="preserve">
-    <value>General</value>
-    <comment>A general settings category</comment>
+    <value>General</value><comment>A general settings category</comment>
   </data>
   <data name="Label_Inference" xml:space="preserve">
-    <value>Inference</value>
-    <comment>The Inference feature page</comment>
+    <value>Inference</value><comment>The Inference feature page</comment>
   </data>
   <data name="Label_Prompt" xml:space="preserve">
-    <value>プロンプト</value>
-    <comment>A settings category for Inference generation prompts</comment>
+    <value>プロンプト</value><comment>A settings category for Inference generation prompts</comment>
   </data>
   <data name="Label_OutputImageFiles" xml:space="preserve">
     <value>アウトプット画像</value>
@@ -869,8 +864,7 @@
     <value>入力補完でアンダースコアをスペースに置き換える</value>
   </data>
   <data name="Label_PromptTags" xml:space="preserve">
-    <value>Prompt Tags</value>
-    <comment>Tags for image generation prompts</comment>
+    <value>Prompt Tags</value><comment>Tags for image generation prompts</comment>
   </data>
   <data name="Label_PromptTagsImport" xml:space="preserve">
     <value>Import Prompt tags</value>
@@ -888,12 +882,10 @@
     <value>Hugging Face</value>
   </data>
   <data name="Label_Addons" xml:space="preserve">
-    <value>Addons</value>
-    <comment>Inference Sampler Addons</comment>
+    <value>Addons</value><comment>Inference Sampler Addons</comment>
   </data>
   <data name="Label_SaveIntermediateImage" xml:space="preserve">
-    <value>中間画像を保存</value>
-    <comment>Inference module step to save an intermediate image</comment>
+    <value>中間画像を保存</value><comment>Inference module step to save an intermediate image</comment>
   </data>
   <data name="Label_Settings" xml:space="preserve">
     <value>設定</value>
@@ -962,6 +954,12 @@
   <data name="Action_CopyDetails" xml:space="preserve">
     <value>Copy Details</value>
   </data>
+  <data name="Label_Notifications" xml:space="preserve">
+    <value>通知</value>
+  </data>
+  <data name="Label_NotificationOption_None" xml:space="preserve">
+    <value>None</value>
+  </data>
   <data name="Action_Download" xml:space="preserve">
     <value>ダウンロード</value>
   </data>
@@ -973,12 +971,6 @@
   </data>
   <data name="Label_RecommendedModelsSubText" xml:space="preserve">
     <value>Packageのインストール中に、推奨Modelをいくつかご紹介しましょう。</value>
-  </data>
-  <data name="Label_Notifications" xml:space="preserve">
-    <value>通知</value>
-  </data>
-  <data name="Label_NotificationOption_None" xml:space="preserve">
-    <value>None</value>
   </data>
   <data name="Label_ComfyRequiredTitle" xml:space="preserve">
     <value>ComfyUIが必要です</value>
@@ -992,8 +984,32 @@
   <data name="Label_SelectDownloadLocation" xml:space="preserve">
     <value>ダウンロード先を選んでください:</value>
   </data>
+  <data name="Label_Workflows" xml:space="preserve">
+    <value>ワークフロー</value>
+  </data>
+  <data name="Label_InfiniteScrolling" xml:space="preserve">
+    <value>無限スクロール</value>
+  </data>
+  <data name="Label_WorkflowBrowser" xml:space="preserve">
+    <value>ワークフローブラウザ</value>
+  </data>
   <data name="Label_Config" xml:space="preserve">
     <value>設定</value>
+  </data>
+  <data name="Action_OpenOnOpenArt" xml:space="preserve">
+    <value>OpenArtで開く</value>
+  </data>
+  <data name="Label_NodeDetails" xml:space="preserve">
+    <value>ノード詳細</value>
+  </data>
+  <data name="Label_WorkflowDescription" xml:space="preserve">
+    <value>ワークフロー概要</value>
+  </data>
+  <data name="Label_OpenArtBrowser" xml:space="preserve">
+    <value>OpenArtブラウザ</value>
+  </data>
+  <data name="Action_PreviewPreprocessor" xml:space="preserve">
+    <value>プリプロセッサをプレビュー</value>
   </data>
   <data name="Label_ToggleAutoScrolling" xml:space="preserve">
     <value>最後まで自動スクロール</value>
@@ -1033,30 +1049,6 @@
   </data>
   <data name="Label_ModelBrowser" xml:space="preserve">
     <value>Model Brouser</value>
-  </data>
-  <data name="Label_Workflows" xml:space="preserve">
-    <value>ワークフロー</value>
-  </data>
-  <data name="Label_InfiniteScrolling" xml:space="preserve">
-    <value>無限スクロール</value>
-  </data>
-  <data name="Label_WorkflowBrowser" xml:space="preserve">
-    <value>ワークフローブラウザ</value>
-  </data>
-  <data name="Action_OpenOnOpenArt" xml:space="preserve">
-    <value>OpenArtで開く</value>
-  </data>
-  <data name="Label_NodeDetails" xml:space="preserve">
-    <value>ノード詳細</value>
-  </data>
-  <data name="Label_WorkflowDescription" xml:space="preserve">
-    <value>ワークフロー概要</value>
-  </data>
-  <data name="Label_OpenArtBrowser" xml:space="preserve">
-    <value>OpenArtブラウザ</value>
-  </data>
-  <data name="Action_PreviewPreprocessor" xml:space="preserve">
-    <value>プリプロセッサをプレビュー</value>
   </data>
   <data name="TeachingTip_WebUiButtonMoved" xml:space="preserve">
     <value>&apos;Web UIを開く&apos;ボタンがコマンドバーに移動しました</value>
@@ -1147,5 +1139,137 @@
   </data>
   <data name="Warning_PleaseExtractFirst" xml:space="preserve">
     <value>Stability Matrixを実行する前に、ZIPファイルからアプリを抽出してください</value>
+  </data>
+    <data name="Label_HistorySize" xml:space="preserve">
+    <value>History Size</value>
+  </data>
+  <data name="Label_HistorySize_Description" xml:space="preserve">
+    <value>The number of lines above the ones displayed in the console you can scroll back to</value>
+  </data>
+  <data name="Label_ConnectAccountFailed" xml:space="preserve">
+    <value>We had some trouble connecting your account</value>
+  </data>
+  <data name="Label_EditModelMetadata" xml:space="preserve">
+    <value>Edit Model Metadata</value>
+  </data>
+  <data name="Label_NSFW" xml:space="preserve">
+    <value>NSFW</value>
+  </data>
+  <data name="Label_Tags" xml:space="preserve">
+    <value>Tags</value>
+  </data>
+  <data name="Label_VersionName" xml:space="preserve">
+    <value>Version Name</value>
+  </data>
+  <data name="Label_TrainedWords" xml:space="preserve">
+    <value>Trained Words</value>
+  </data>
+  <data name="Label_PreviewImage" xml:space="preserve">
+    <value>Preview Image</value>
+  </data>
+  <data name="Label_BatchSize" xml:space="preserve">
+    <value>Batch Size</value>
+  </data>
+  <data name="Label_Batches" xml:space="preserve">
+    <value>Batches</value>
+  </data>
+  <data name="Label_Sampler" xml:space="preserve">
+    <value>Sampler</value>
+  </data>
+  <data name="Label_Scheduler" xml:space="preserve">
+    <value>Scheduler</value>
+  </data>
+  <data name="Label_MaxSize" xml:space="preserve">
+    <value>Max Size</value>
+  </data>
+  <data name="Label_UseSeparatePrompt" xml:space="preserve">
+    <value>Use Separate Prompt</value>
+  </data>
+  <data name="Label_Seed" xml:space="preserve">
+    <value>Seed</value>
+  </data>
+  <data name="Label_NegativePrompt" xml:space="preserve">
+    <value>Negative Prompt</value>
+  </data>
+  <data name="Label_NewFolder" xml:space="preserve">
+    <value>New Folder</value>
+  </data>
+  <data name="Label_CopyLinkToClipboard" xml:space="preserve">
+    <value>Copy Link to Clipboard</value>
+  </data>
+  <data name="TextTemplate_OAuthLoginTitle" xml:space="preserve">
+    <value>Sign in with {0}</value><comment>e.g. 'Sign in with Google'</comment>
+  </data>
+  <data name="Text_AllowBrowserOpenAppLink" xml:space="preserve">
+    <value>Please allow your browser to open this app when prompted to continue.</value>
+  </data>
+  <data name="Text_OAuthLoginDescription" xml:space="preserve">
+    <value>Open the link in your browser and follow the instructions to connect your account.</value>
+  </data>
+  <data name="Label_PythonDependenciesOverride_Title" xml:space="preserve">
+    <value>Python Dependencies Override</value>
+  </data>
+  <data name="Label_PythonDependenciesOverride_Description" xml:space="preserve">
+    <value>Add, replace, or remove dependencies for install and update</value>
+  </data>
+  <data name="Label_DependencySpecifiers" xml:space="preserve">
+    <value>Dependency Specifiers</value>
+  </data>
+  <data name="AnalyticsExample_InstallData" xml:space="preserve">
+    <value>{
+  "packageName": "stable-diffusion-webui",
+  "packageVersion": "v1.10.0",
+  "isSuccess": true,
+  "type": "install",
+  "timestamp": "2024-09-04T02:14:04.1967404+00:00"
+}</value>
+  </data>
+  <data name="Label_Analytics" xml:space="preserve">
+    <value>Analytics</value>
+  </data>
+  <data name="TextTemplate_YouCanChangeThisBehavior" xml:space="preserve">
+    <value>You can always change this behavior in {0}.</value><comment>e.g. 'You can always change this behavior in Settings &gt; Category &gt; Item.'</comment>
+  </data>
+  <data name="Text_AnalyticsDescription" xml:space="preserve">
+    <value>Help us improve Stability Matrix by sending anonymous data about features used, operating system versions, types of packages installed, etc. The data sent is never associated with you or your account and will not include personal data or any sensitive information.</value>
+  </data>
+  <data name="Text_AnalyticsDescriptionShort" xml:space="preserve">
+    <value>Help us improve Stability Matrix by sending anonymous data about features used, operating system versions, types of packages installed, etc.</value>
+  </data>
+  <data name="Text_AnalyticsDataPrivacyInfo" xml:space="preserve">
+    <value>The data sent is never associated with you or your account and will not include personal data or any sensitive information.</value>
+  </data>
+  <data name="Label_UsageData" xml:space="preserve">
+    <value>Usage data</value>
+  </data>
+  <data name="Label_PrivacyPolicy" xml:space="preserve">
+    <value>Privacy Policy</value>
+  </data>
+  <data name="Label_ImageHidden" xml:space="preserve">
+    <value>Image Hidden</value>
+  </data>
+  <data name="Label_NoImageFound" xml:space="preserve">
+    <value>No Image Found</value>
+  </data>
+  <data name="Label_HideEmptyCategories" xml:space="preserve">
+    <value>Hide Empty Categories</value>
+  </data>
+  <data name="Label_ShowNsfwImages" xml:space="preserve">
+    <value>Show NSFW Images</value>
+  </data>
+  <data name="Label_EnableLongPaths" xml:space="preserve">
+    <value>Enable Long Paths</value><comment>(Setting to enable long file paths on windows)</comment>
+  </data>
+  <data name="Label_EnableLongPathsDescription" xml:space="preserve">
+    <value>Remove MAX_PATH limitations from common Win32 file and directory functions</value><comment>(Setting to enable long file paths on windows)</comment>
+  </data>
+  <data name="Label_SystemSettings" xml:space="preserve">
+    <value>System Settings</value>
+  </data>
+  <data name="Label_ChangesApplied" xml:space="preserve">
+    <value>Changes Applied</value>
+  </data>
+  <data name="Text_RestartMayBeRequiredForSystemChanges" xml:space="preserve">
+    <value>A restart may be required for system changes to take effect.</value>
   </data>
 </root>


### PR DESCRIPTION
## Description

This PR includes some housekeeping and minor improvements to Japanese translations.

### Changes include:

- Refined wording in several Japanese strings for clarity and naturalness
- Corrected a few minor grammatical issues
- Aligned some translations more closely with the English source text
- Updated terminology for consistency across the application

These changes are primarily maintenance-oriented and aim to enhance the overall quality of our Japanese localization without introducing any significant functional changes.

Please review the changes and let me know if any further adjustments are needed.