### PR TITLE
[Feat/simplesdxl-package] Add SimpleSDXL as package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 # Mono auto generated files
 mono_crash.*
 
+# Rider
+.idea/
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Multi-Platform Package Manager and Inference UI for Stable Diffusion
 ### 🖱️ One click install and update for Stable Diffusion Web UI Packages
 - Supports:
   - [Stable Diffusion WebUI reForge][reforge], [Stable Diffusion WebUI Forge][forge], [Automatic 1111][auto1111], [Automatic 1111 DirectML][auto1111-directml], [SD Web UI-UX][webui-ux], [SD.Next][sdnext]
-  - [Fooocus][fooocus], [Fooocus MRE][fooocus-mre], [Fooocus ControlNet SDXL][fooocus-controlnet], [Ruined Fooocus][ruined-fooocus], [Fooocus - mashb1t's 1-Up Edition][fooocus-mashb1t]
+  - [Fooocus][fooocus], [Fooocus MRE][fooocus-mre], [Fooocus ControlNet SDXL][fooocus-controlnet], [Ruined Fooocus][ruined-fooocus], [Fooocus - mashb1t's 1-Up Edition][fooocus-mashb1t], [SimpleSDXL](https://github.com/metercai/SimpleSDXL/)
   - [ComfyUI][comfy]
   - [StableSwarmUI][stable-swarm]
   - [VoltaML][voltaml]

--- a/StabilityMatrix.Core/Helper/Factory/PackageFactory.cs
+++ b/StabilityMatrix.Core/Helper/Factory/PackageFactory.cs
@@ -89,6 +89,8 @@ public class PackageFactory : IPackageFactory
             "mashb1t-fooocus"
                 => new Mashb1tFooocus(githubApiCache, settingsManager, downloadService, prerequisiteHelper),
             "reforge" => new Reforge(githubApiCache, settingsManager, downloadService, prerequisiteHelper),
+            "SimpleSDXL"
+                => new SimpleSDXL(githubApiCache, settingsManager, downloadService, prerequisiteHelper),
             _ => throw new ArgumentOutOfRangeException(nameof(installedPackage))
         };
     }

--- a/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
+++ b/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
@@ -1,4 +1,4 @@
-﻿using StabilityMatrix.Core.Attributes;
+using StabilityMatrix.Core.Attributes;
 using StabilityMatrix.Core.Helper;
 using StabilityMatrix.Core.Helper.Cache;
 using StabilityMatrix.Core.Helper.HardwareInfo;
@@ -34,6 +34,27 @@ public class SimpleSDXL(
 
     public override List<LaunchOptionDefinition> LaunchOptions =>
         [
+            new()
+            {
+                Name = "Preset",
+                Type = LaunchOptionType.Bool,
+                Options =
+                {
+                    "--preset anime",
+                    "--preset realistic",
+                    "--preset Flux",
+                    "--preset Kolors",
+                    "--preset pony_v6"
+                },
+            },
+            new()
+            {
+                Name = "Language",
+                Type = LaunchOptionType.String,
+                Description = "Change the language of the UI",
+                Options = { "--language" },
+                DefaultValue = "en"
+            },
             new()
             {
                 Name = "Port",

--- a/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
+++ b/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
@@ -1,4 +1,4 @@
-using StabilityMatrix.Core.Attributes;
+﻿using StabilityMatrix.Core.Attributes;
 using StabilityMatrix.Core.Helper;
 using StabilityMatrix.Core.Helper.Cache;
 using StabilityMatrix.Core.Helper.HardwareInfo;
@@ -97,10 +97,11 @@ public class SimpleSDXL(
             await using var venvRunner = await SetupVenvPure(installLocation, forceRecreate: true)
                 .ConfigureAwait(false);
 
+            progress?.Report(new ProgressReport(-1f, "Installing requirements...", isIndeterminate: true));
+
             // Get necessary dependencies
             await venvRunner.PipInstall("--upgrade pip", onConsoleOutput).ConfigureAwait(false);
             await venvRunner.PipInstall("nvidia-pyindex pygit2", onConsoleOutput).ConfigureAwait(false);
-            progress?.Report(new ProgressReport(-1f, "Installing requirements...", isIndeterminate: true));
             await venvRunner.PipInstall("facexlib cpm_kernels", onConsoleOutput).ConfigureAwait(false);
 
             // Download and Install pre-built insightface
@@ -113,10 +114,13 @@ public class SimpleSDXL(
 
             var requirements = new FilePath(installLocation, "requirements_versions.txt");
             var pipArgs = new PipInstallArgs()
+                .WithTorch("==2.3.1")
+                .WithTorchVision("==0.18.1")
+                .WithTorchAudio("==2.3.1")
                 .WithTorchExtraIndex("cu121")
                 .WithParsedFromRequirementsTxt(
                     await requirements.ReadAllTextAsync(cancellationToken).ConfigureAwait(false),
-                    ""
+                    "torch"
                 );
 
             if (installedPackage.PipOverrides != null)

--- a/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
+++ b/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
@@ -1,7 +1,6 @@
 using StabilityMatrix.Core.Attributes;
 using StabilityMatrix.Core.Helper;
 using StabilityMatrix.Core.Helper.Cache;
-using StabilityMatrix.Core.Helper.HardwareInfo;
 using StabilityMatrix.Core.Models.FileInterfaces;
 using StabilityMatrix.Core.Models.Progress;
 using StabilityMatrix.Core.Processes;

--- a/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
+++ b/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
@@ -88,6 +88,8 @@ public class SimpleSDXL(
             await using var venvRunner = await SetupVenvPure(installLocation, forceRecreate: true)
                 .ConfigureAwait(false);
 
+            await venvRunner.PipInstall("--upgrade pip", onConsoleOutput).ConfigureAwait(false);
+            await venvRunner.PipInstall("nvidia-pyindex", onConsoleOutput).ConfigureAwait(false);
             progress?.Report(new ProgressReport(-1f, "Installing requirements...", isIndeterminate: true));
 
             var requirements = new FilePath(installLocation, "requirements_versions.txt");
@@ -95,7 +97,7 @@ public class SimpleSDXL(
                 .WithTorchExtraIndex("cu121")
                 .WithParsedFromRequirementsTxt(
                     await requirements.ReadAllTextAsync(cancellationToken).ConfigureAwait(false),
-                    "--extra-index-url.*|--index-url.*"
+                    ""
                 );
 
             if (installedPackage.PipOverrides != null)

--- a/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
+++ b/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
@@ -1,0 +1,124 @@
+﻿using StabilityMatrix.Core.Attributes;
+using StabilityMatrix.Core.Helper;
+using StabilityMatrix.Core.Helper.Cache;
+using StabilityMatrix.Core.Helper.HardwareInfo;
+using StabilityMatrix.Core.Models.FileInterfaces;
+using StabilityMatrix.Core.Models.Progress;
+using StabilityMatrix.Core.Processes;
+using StabilityMatrix.Core.Python;
+using StabilityMatrix.Core.Services;
+
+namespace StabilityMatrix.Core.Models.Packages;
+
+[Singleton(typeof(BasePackage))]
+public class SimpleSDXL(
+    IGithubApiCache githubApi,
+    ISettingsManager settingsManager,
+    IDownloadService downloadService,
+    IPrerequisiteHelper prerequisiteHelper
+) : Fooocus(githubApi, settingsManager, downloadService, prerequisiteHelper)
+{
+    public override string Name => "SimpleSDXL";
+    public override string DisplayName { get; set; } = "SimpleSDXL";
+    public override string Author => "metercai";
+    public override string Blurb =>
+        "Enhanced version of Fooocus for SDXL, more suitable for Chinese and Cloud. Supports Flux.";
+    public override string LicenseUrl => "https://github.com/metercai/SimpleSDXL/blob/SimpleSDXL/LICENSE";
+    public override Uri PreviewImageUri =>
+        new("https://github.com/user-attachments/assets/98715a4d-9f4a-4846-ae62-eb8d69793d31");
+    public override PackageDifficulty InstallerSortOrder => PackageDifficulty.Expert;
+    public override IEnumerable<SharedFolderMethod> AvailableSharedFolderMethods =>
+        [SharedFolderMethod.Symlink, SharedFolderMethod.None];
+    public override SharedFolderMethod RecommendedSharedFolderMethod => SharedFolderMethod.Symlink;
+
+    public override List<LaunchOptionDefinition> LaunchOptions =>
+        [
+            new()
+            {
+                Name = "Port",
+                Type = LaunchOptionType.String,
+                Description = "Sets the listen port",
+                Options = { "--port" }
+            },
+            new()
+            {
+                Name = "Share",
+                Type = LaunchOptionType.Bool,
+                Description = "Set whether to share on Gradio",
+                Options = { "--share" }
+            },
+            new()
+            {
+                Name = "Listen",
+                Type = LaunchOptionType.String,
+                Description = "Set the listen interface",
+                Options = { "--listen" }
+            },
+            new()
+            {
+                Name = "Auth",
+                Type = LaunchOptionType.String,
+                Description = "Set credentials username/password",
+                Options = { "--auth" }
+            },
+            new()
+            {
+                Name = "No Browser",
+                Type = LaunchOptionType.Bool,
+                Description = "Do not launch in browser",
+                Options = { "--nobrowser" }
+            },
+            LaunchOptionDefinition.Extras
+        ];
+
+    public override async Task InstallPackage(
+        string installLocation,
+        InstalledPackage installedPackage,
+        InstallPackageOptions options,
+        IProgress<ProgressReport>? progress = null,
+        Action<ProcessOutput>? onConsoleOutput = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var torchVersion = options.PythonOptions.TorchIndex ?? GetRecommendedTorchVersion();
+
+        if (torchVersion == TorchIndex.Cuda)
+        {
+            await using var venvRunner = await SetupVenvPure(installLocation, forceRecreate: true)
+                .ConfigureAwait(false);
+
+            progress?.Report(new ProgressReport(-1f, "Installing requirements...", isIndeterminate: true));
+
+            var requirements = new FilePath(installLocation, "requirements_versions.txt");
+            var pipArgs = new PipInstallArgs()
+                .WithTorchExtraIndex("cu121")
+                .WithParsedFromRequirementsTxt(
+                    await requirements.ReadAllTextAsync(cancellationToken).ConfigureAwait(false),
+                    "--extra-index-url.*|--index-url.*"
+                );
+
+            if (installedPackage.PipOverrides != null)
+            {
+                pipArgs = pipArgs.WithUserOverrides(installedPackage.PipOverrides);
+            }
+
+            await venvRunner.PipInstall(pipArgs, onConsoleOutput).ConfigureAwait(false);
+        }
+        else
+        {
+            await base.InstallPackage(
+                installLocation,
+                installedPackage,
+                options,
+                progress,
+                onConsoleOutput,
+                cancellationToken
+            )
+                .ConfigureAwait(false);
+        }
+
+        // Create output folder since it's not created by default
+        var outputFolder = new DirectoryPath(installLocation, OutputFolderName);
+        outputFolder.Create();
+    }
+}

--- a/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
+++ b/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
@@ -55,20 +55,6 @@ public class SimpleSDXL(
                 Description = "Set the listen interface",
                 Options = { "--listen" }
             },
-            new()
-            {
-                Name = "Auth",
-                Type = LaunchOptionType.String,
-                Description = "Set credentials username/password",
-                Options = { "--auth" }
-            },
-            new()
-            {
-                Name = "No Browser",
-                Type = LaunchOptionType.Bool,
-                Description = "Do not launch in browser",
-                Options = { "--nobrowser" }
-            },
             LaunchOptionDefinition.Extras
         ];
 

--- a/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
+++ b/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
@@ -30,6 +30,7 @@ public class SimpleSDXL(
     public override IEnumerable<SharedFolderMethod> AvailableSharedFolderMethods =>
         [SharedFolderMethod.Symlink, SharedFolderMethod.None];
     public override SharedFolderMethod RecommendedSharedFolderMethod => SharedFolderMethod.Symlink;
+    public override string MainBranch => "SimpleSDXL";
 
     public override List<LaunchOptionDefinition> LaunchOptions =>
         [

--- a/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
+++ b/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
@@ -107,7 +107,7 @@ public class SimpleSDXL(
 
             // Download and Install pre-built insightface
             var wheelPath = new FilePath(installLocation, "insightface-0.7.3-cp310-cp310-win_amd64.whl");
-            await downloadService
+            await DownloadService
                 .DownloadToFileAsync(wheelUrl, wheelPath, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
             await venvRunner.PipInstall($"{wheelPath}", onConsoleOutput).ConfigureAwait(false);

--- a/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
+++ b/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
@@ -88,6 +88,7 @@ public class SimpleSDXL(
                 .DownloadToFileAsync(wheelUrl, wheelPath, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
             await venvRunner.PipInstall($"{wheelPath}", onConsoleOutput).ConfigureAwait(false);
+            await wheelPath.DeleteAsync(cancellationToken).ConfigureAwait(false);
 
             var requirements = new FilePath(installLocation, "requirements_versions.txt");
             var pipArgs = new PipInstallArgs()

--- a/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
+++ b/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
@@ -1,4 +1,4 @@
-using StabilityMatrix.Core.Attributes;
+﻿using StabilityMatrix.Core.Attributes;
 using StabilityMatrix.Core.Helper;
 using StabilityMatrix.Core.Helper.Cache;
 using StabilityMatrix.Core.Models.FileInterfaces;
@@ -36,6 +36,7 @@ public class SimpleSDXL(
             new()
             {
                 Name = "Preset",
+                Description = "Apply specified UI preset.",
                 Type = LaunchOptionType.Bool,
                 Options =
                 {
@@ -50,10 +51,9 @@ public class SimpleSDXL(
             {
                 Name = "Language",
                 Type = LaunchOptionType.String,
-                Description = "Change the language of the UI",
-                Options = { "--language" },
+                Description = "Translate UI using json files in [language] folder.",
                 InitialValue = "en",
-                DefaultValue = "en"
+                Options = { "--language" }
             },
             new()
             {
@@ -75,6 +75,75 @@ public class SimpleSDXL(
                 Type = LaunchOptionType.String,
                 Description = "Set the listen interface",
                 Options = { "--listen" }
+            },
+            new()
+            {
+                Name = "Disable preset download",
+                Description = "Disables downloading models for presets",
+                DefaultValue = false,
+                Type = LaunchOptionType.Bool,
+                Options = { "--disable-preset-download" }
+            },
+            new()
+            {
+                Name = "Theme",
+                Description = "Launches the UI with light or dark theme",
+                Type = LaunchOptionType.String,
+                DefaultValue = "dark",
+                Options = { "--theme" }
+            },
+            new()
+            {
+                Name = "Disable offload from VRAM",
+                Description =
+                    "Force loading models to vram when the unload can be avoided. Some Mac users may need this.",
+                Type = LaunchOptionType.Bool,
+                InitialValue = Compat.IsMacOS,
+                Options = { "--disable-offload-from-vram" }
+            },
+            new()
+            {
+                Name = "Disable image log",
+                Description = "Prevent writing images and logs to the outputs folder.",
+                Type = LaunchOptionType.Bool,
+                Options = { "--disable-image-log" }
+            },
+            new()
+            {
+                Name = "Disable metadata",
+                Description = "Disables saving metadata to images.",
+                Type = LaunchOptionType.Bool,
+                Options = { "--disable-metadata" }
+            },
+            new()
+            {
+                Name = "Disable enhance output sorting",
+                Description = "Disables enhance output sorting for final image gallery.",
+                Type = LaunchOptionType.Bool,
+                Options = { "--disable-enhance-output-sorting" }
+            },
+            new()
+            {
+                Name = "Enable auto describe image",
+                Description = "Enables automatic description of uov and enhance image when prompt is empty",
+                DefaultValue = true,
+                Type = LaunchOptionType.Bool,
+                Options = { "--enable-auto-describe-image" }
+            },
+            new()
+            {
+                Name = "Always download new models",
+                Description = "Always download newer models.",
+                DefaultValue = false,
+                Type = LaunchOptionType.Bool,
+                Options = { "--always-download-new-model" }
+            },
+            new()
+            {
+                Name = "Disable comfyd",
+                Description = "Disable auto start comfyd server at launch",
+                Type = LaunchOptionType.Bool,
+                Options = { "--disable-comfyd" }
             },
             LaunchOptionDefinition.Extras
         ];

--- a/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
+++ b/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
@@ -1,4 +1,4 @@
-﻿using StabilityMatrix.Core.Attributes;
+using StabilityMatrix.Core.Attributes;
 using StabilityMatrix.Core.Helper;
 using StabilityMatrix.Core.Helper.Cache;
 using StabilityMatrix.Core.Helper.HardwareInfo;
@@ -53,6 +53,7 @@ public class SimpleSDXL(
                 Type = LaunchOptionType.String,
                 Description = "Change the language of the UI",
                 Options = { "--language" },
+                InitialValue = "en",
                 DefaultValue = "en"
             },
             new()


### PR DESCRIPTION
From Discord: https://canary.discord.com/channels/1115555685476868168/1297228642870493234/1297228642870493234
(I'm `nullping` on Discord)

I want to add [SimpleSDXL](<https://github.com/metercai/SimpleSDXL>) as a package which is a fork of [Fooocus](<https://github.com/lllyasviel/Fooocus>) just like [RuinedFooocus](<https://github.com/runew0lf/RuinedFooocus>). It adds support for Flux, Pony, has a better architecture, more presets, etc.

There were a lot of hiccups down the road because that package does [not have the best dependency management](https://github.com/metercai/SimpleSDXL/issues/88), but I managed to fix all the issues now. 

![image](https://github.com/user-attachments/assets/e2dc1053-f9fe-4bad-abb9-492e5afa3b62)
![image](https://github.com/user-attachments/assets/9f7c0000-f568-4474-a382-2e357e1d77d2)
![image](https://github.com/user-attachments/assets/8cb95c85-8b19-4cb8-b9dc-aa530e85e51e)
