### PR TITLE
Update the file StabilityMatrix.Native.csproj so that the project can be debugged or run directly in the VisualStudio environment.

### DIFF
--- a/StabilityMatrix.Native/StabilityMatrix.Native.csproj
+++ b/StabilityMatrix.Native/StabilityMatrix.Native.csproj
@@ -1,37 +1,38 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<RuntimeIdentifiers>win-x64;linux-x64;osx-x64;osx-arm64</RuntimeIdentifiers>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<PlatformTarget>AnyCPU</PlatformTarget>
+	</PropertyGroup>
 
-    <PropertyGroup>
-        <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows>
-        <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsOSX>
-        <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
-    </PropertyGroup>
+	<PropertyGroup Condition="'$(RuntimeIdentifier)' == 'win-x64'">
+		<DefineConstants>Windows</DefineConstants>
+		<IsWindows>true</IsWindows>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or '$(RuntimeIdentifier)' == 'osx-arm64'">
+		<DefineConstants>OSX</DefineConstants>
+		<IsOSX>true</IsOSX>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
+		<DefineConstants>Linux</DefineConstants>
+		<IsLinux>true</IsLinux>
+	</PropertyGroup>
 
-    <PropertyGroup Condition="'$(IsWindows)'=='true'">
-        <DefineConstants>Windows</DefineConstants>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(IsOSX)'=='true'">
-        <DefineConstants>OSX</DefineConstants>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(IsLinux)'=='true'">
-        <DefineConstants>Linux</DefineConstants>
-    </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<Optimize>false</Optimize>
+	</PropertyGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\StabilityMatrix.Native.Abstractions\StabilityMatrix.Native.Abstractions.csproj" />
-    </ItemGroup>
-    
-    <ItemGroup Condition="'$(RuntimeIdentifier)' == 'win-x64'">
-      <ProjectReference Include="..\StabilityMatrix.Native.Windows\StabilityMatrix.Native.Windows.csproj" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or '$(RuntimeIdentifier)' == 'osx-arm64'">
-        <ProjectReference Include="..\StabilityMatrix.Native.macOS\StabilityMatrix.Native.macOS.csproj" />
-    </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\StabilityMatrix.Native.Abstractions\StabilityMatrix.Native.Abstractions.csproj" />
+	</ItemGroup>
 
+	<ItemGroup Condition="'$(RuntimeIdentifier)' == 'win-x64'">
+		<ProjectReference Include="..\StabilityMatrix.Native.Windows\StabilityMatrix.Native.Windows.csproj" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or '$(RuntimeIdentifier)' == 'osx-arm64'">
+		<ProjectReference Include="..\StabilityMatrix.Native.macOS\StabilityMatrix.Native.macOS.csproj" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
In the .csproj file, the expression of $([System.Runtime.InteropServices.RuntimeInformation]...) is not a directly supported MSBuild expression. MSBuild does not support calling runtime APIs directly in <PropertyGroup>.

This results in the inability to directly debug or run the StabilityMatrix.Avalonia project after opening the project with VisualStudio.

Should be replaced by a RuntimeIdentifier based condition, for example:

<PropertyGroup Condition="'$(RuntimeIdentifier)' == 'win-x64'">
    <IsWindows>true</IsWindows>
</PropertyGroup>
<PropertyGroup Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or '$(RuntimeIdentifier)' == 'osx-arm64'">
    <IsOSX>true</IsOSX>
</PropertyGroup>
<PropertyGroup Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
    <IsLinux>true</IsLinux>
</PropertyGroup>