### PR TITLE
Improve GenerationParameters fields parsing

### DIFF
--- a/StabilityMatrix.Tests/Models/GenerationParametersTests.cs
+++ b/StabilityMatrix.Tests/Models/GenerationParametersTests.cs
@@ -51,20 +51,169 @@ public class GenerationParametersTests
     }
 
     [TestMethod]
-    public void TestParseLineFields()
+    // basic data
+    [DataRow(
+        """Steps: 30, Sampler: DPM++ 2M Karras, CFG scale: 7, Seed: 2216407431, Size: 640x896, Model hash: eb2h052f91, Model: anime_v1""",
+        7,
+        "30",
+        "DPM++ 2M Karras",
+        "7",
+        "2216407431",
+        "640x896",
+        "eb2h052f91",
+        "anime_v1",
+        new string[] { "Steps", "Sampler", "CFG scale", "Seed", "Size", "Model hash", "Model" }
+    )]
+    // duplicated keys
+    [DataRow(
+        """Steps: 30, Sampler: DPM++ 2M Karras, CFG scale: 7, Seed: 2216407431, Size: 640x896, Model hash: eb2h052f91, Model: anime_v1, Steps: 40, Sampler: Whatever, CFG scale: 1, Seed: 1234567890, Size: 1024x1024, Model hash: 1234567890, Model: anime_v2""",
+        7,
+        "30",
+        "DPM++ 2M Karras",
+        "7",
+        "2216407431",
+        "640x896",
+        "eb2h052f91",
+        "anime_v1",
+        new string[] { "Steps", "Sampler", "CFG scale", "Seed", "Size", "Model hash", "Model" }
+    )]
+    public void TestParseLineFields(
+        string line,
+        int totalFields,
+        string? expectedSteps,
+        string? expectedSampler,
+        string? expectedCfgScale,
+        string? expectedSeed,
+        string? expectedSize,
+        string? expectedModelHash,
+        string? expectedModel,
+        string[] expectedKeys
+    )
     {
-        const string lastLine =
-            @"Steps: 30, Sampler: DPM++ 2M Karras, CFG scale: 7, Seed: 2216407431, Size: 640x896, Model hash: eb2h052f91, Model: anime_v1";
+        var fields = GenerationParameters.ParseLine(line);
 
-        var fields = GenerationParameters.ParseLine(lastLine);
+        Assert.AreEqual(totalFields, fields.Count);
+        Assert.AreEqual(expectedSteps, fields["Steps"]);
+        Assert.AreEqual(expectedSampler, fields["Sampler"]);
+        Assert.AreEqual(expectedCfgScale, fields["CFG scale"]);
+        Assert.AreEqual(expectedSeed, fields["Seed"]);
+        Assert.AreEqual(expectedSize, fields["Size"]);
+        Assert.AreEqual(expectedModelHash, fields["Model hash"]);
+        Assert.AreEqual(expectedModel, fields["Model"]);
+        CollectionAssert.AreEqual(expectedKeys, fields.Keys);
+    }
 
-        Assert.AreEqual(7, fields.Count);
-        Assert.AreEqual("30", fields["Steps"]);
-        Assert.AreEqual("DPM++ 2M Karras", fields["Sampler"]);
-        Assert.AreEqual("7", fields["CFG scale"]);
-        Assert.AreEqual("2216407431", fields["Seed"]);
-        Assert.AreEqual("640x896", fields["Size"]);
-        Assert.AreEqual("eb2h052f91", fields["Model hash"]);
-        Assert.AreEqual("anime_v1", fields["Model"]);
+    [TestMethod]
+    // empty line
+    [DataRow("", new string[] { })]
+    [DataRow("  ", new string[] { })]
+    // basic data
+    [DataRow(
+        "Steps: 30, Sampler: DPM++ 2M Karras, CFG scale: 7, Seed: 2216407431, Size: 640x896, Model hash: eb2h052f91, Model: anime_v1",
+        new string[] { "Steps", "Sampler", "CFG scale", "Seed", "Size", "Model hash", "Model" }
+    )]
+    // no spaces
+    [DataRow(
+        "Steps:30,Sampler:DPM++2MKarras,CFGscale:7,Seed:2216407431,Size:640x896,Modelhash:eb2h052f91,Model:anime_v1",
+        new string[] { "Steps", "Sampler", "CFGscale", "Seed", "Size", "Modelhash", "Model" }
+    )]
+    // extra commas
+    [DataRow(
+        "Steps: 30, Sampler: DPM++ 2M Karras, CFG scale: 7, Seed: 2216407431, Size: 640x896,,,,,, Model hash: eb2h052f91, Model: anime_v1,,,,,,,",
+        new string[] { "Steps", "Sampler", "CFG scale", "Seed", "Size", "Model hash", "Model" }
+    )]
+    // quoted string
+    [DataRow(
+        """Name: "John, Doe", Json: {"key:with:colon": "value, with, comma"}, It still: should work""",
+        new string[] { "Name", "Json", "It still" }
+    )]
+    // extra ending brackets
+    [DataRow(
+        """Name: "John, Doe", Json: {"key:with:colon": "value, with, comma"}}}}}}}})))>>, It still: should work""",
+        new string[] { "Name", "Json", "It still" }
+    )]
+    // civitai
+    [DataRow(
+        """Steps: 8, Sampler: Euler, CFG scale: 1, Seed: 12346789098, Size: 832x1216, Clip skip: 2, Created Date: 2024-12-22T01:01:01.0222111Z, Civitai resources: [{"type":"checkpoint","modelVersionId":123456,"modelName":"Some model name here [Pony XL] which hopefully doesnt contains half pair of quotes and brackets","modelVersionName":"v2.0"},{"type":"lycoris","weight":0.7,"modelVersionId":11111111,"modelName":"some style","modelVersionName":"v1.0 pony"},{"type":"lora","weight":1,"modelVersionId":222222222,"modelName":"another name","modelVersionName":"v1.0"},{"type":"lora","modelVersionId":3333333,"modelName":"name for 33333333333","modelVersionName":"version name here"}], Civitai metadata: {"remixOfId":11111100000}""",
+        new string[]
+        {
+            "Steps",
+            "Sampler",
+            "CFG scale",
+            "Seed",
+            "Size",
+            "Clip skip",
+            "Created Date",
+            "Civitai resources",
+            "Civitai metadata"
+        }
+    )]
+    // github.com/nkchocoai/ComfyUI-SaveImageWithMetaData
+    [DataRow(
+        """Steps: 20, Sampler: DPM++ SDE Karras, CFG scale: 6.0, Seed: 1111111111111, Clip skip: 2, Size: 1024x1024, Model: the_main_model.safetensors, Model hash: ababababab, Lora_0 Model name: name_of_the_first_lora.safetensors, Lora_0 Model hash: ababababab, Lora_0 Strength model: -1.1, Lora_0 Strength clip: -1.1, Lora_1 Model name: name_of_the_second_lora.safetensors, Lora_1 Model hash: ababababab, Lora_1 Strength model: 1, Lora_1 Strength clip: 1, Lora_2 Model name: name_of_the_third_lora.safetensors, Lora_2 Model hash: ababababab, Lora_2 Strength model: 0.9, Lora_2 Strength clip: 0.9, Hashes: {"model": "ababababab", "lora:name_of_the_first_lora": "ababababab", "lora:name_of_the_second_lora": "ababababab", "lora:name_of_the_third_lora": "ababababab"}""",
+        new string[]
+        {
+            "Steps",
+            "Sampler",
+            "CFG scale",
+            "Seed",
+            "Clip skip",
+            "Size",
+            "Model",
+            "Model hash",
+            "Lora_0 Model name",
+            "Lora_0 Model hash",
+            "Lora_0 Strength model",
+            "Lora_0 Strength clip",
+            "Lora_1 Model name",
+            "Lora_1 Model hash",
+            "Lora_1 Strength model",
+            "Lora_1 Strength clip",
+            "Lora_2 Model name",
+            "Lora_2 Model hash",
+            "Lora_2 Strength model",
+            "Lora_2 Strength clip",
+            "Hashes"
+        }
+    )]
+    // asymmetrical bracket
+    [DataRow(
+        """Steps: 20, Missing closing bracket: {"name": "Someone did not close [this bracket"}, But: the parser, should: still return, the: fields before it""",
+        new string[] { "Steps", "Missing closing bracket" }
+    )]
+    public void TestParseLineEdgeCases(string line, string[] expectedKeys)
+    {
+        var fields = GenerationParameters.ParseLine(line);
+
+        Assert.AreEqual(expectedKeys.Length, fields.Count);
+        CollectionAssert.AreEqual(expectedKeys, fields.Keys);
+    }
+
+    [TestMethod]
+    public void TestParseLine()
+    {
+        var fields = GenerationParameters.ParseLine(
+            """Steps: 8, Sampler: Euler, CFG scale: 1, Seed: 12346789098, Size: 832x1216, Clip skip: 2, """
+                + """Created Date: 2024-12-22T01:01:01.0222111Z, Civitai resources: [{"type":"checkpoint","modelVersionId":123456,"modelName":"Some model name here [Pony XL] which hopefully doesnt contains half pair of quotes and brackets","modelVersionName":"v2.0"},{"type":"lycoris","weight":0.7,"modelVersionId":11111111,"modelName":"some style","modelVersionName":"v1.0 pony"},{"type":"lora","weight":1,"modelVersionId":222222222,"modelName":"another name","modelVersionName":"v1.0"},{"type":"lora","modelVersionId":3333333,"modelName":"name for 33333333333","modelVersionName":"version name here"}], Civitai metadata: {"remixOfId":11111100000},"""
+                + """Hashes: {"model": "1234455678", "lora:aaaaaaa": "1234455678", "lora:bbbbbb": "1234455678", "lora:cccccccc": "1234455678"}"""
+        );
+
+        Assert.AreEqual(10, fields.Count);
+        Assert.AreEqual("8", fields["Steps"]);
+        Assert.AreEqual("Euler", fields["Sampler"]);
+        Assert.AreEqual("1", fields["CFG scale"]);
+        Assert.AreEqual("12346789098", fields["Seed"]);
+        Assert.AreEqual("832x1216", fields["Size"]);
+        Assert.AreEqual("2", fields["Clip skip"]);
+        Assert.AreEqual("2024-12-22T01:01:01.0222111Z", fields["Created Date"]);
+        Assert.AreEqual(
+            """[{"type":"checkpoint","modelVersionId":123456,"modelName":"Some model name here [Pony XL] which hopefully doesnt contains half pair of quotes and brackets","modelVersionName":"v2.0"},{"type":"lycoris","weight":0.7,"modelVersionId":11111111,"modelName":"some style","modelVersionName":"v1.0 pony"},{"type":"lora","weight":1,"modelVersionId":222222222,"modelName":"another name","modelVersionName":"v1.0"},{"type":"lora","modelVersionId":3333333,"modelName":"name for 33333333333","modelVersionName":"version name here"}]""",
+            fields["Civitai resources"]
+        );
+        Assert.AreEqual("""{"remixOfId":11111100000}""", fields["Civitai metadata"]);
+        Assert.AreEqual(
+            """{"model": "1234455678", "lora:aaaaaaa": "1234455678", "lora:bbbbbb": "1234455678", "lora:cccccccc": "1234455678"}""",
+            fields["Hashes"]
+        );
     }
 }


### PR DESCRIPTION
Current parser implementation fails to parse metadata generated by https://github.com/nkchocoai/ComfyUI-SaveImageWithMetaData with multiple LORAs.
This new parser is much more forgiving in terms of input text format.

-----

Force push: I have removed `UnquoteValue` since it was added in the [same commit](https://github.com/LykosAI/StabilityMatrix/commit/3c8b65b962a98c4357c3ece588f2d5507040b307) that added regex parsing and it doesn't seems like anything else is depending on a unquoted value right now.