### PR TITLE
Checkpoint manager tooltip fix and filename tooltip change

### DIFF
--- a/StabilityMatrix.Avalonia/Views/CheckpointsPage.axaml
+++ b/StabilityMatrix.Avalonia/Views/CheckpointsPage.axaml
@@ -626,7 +626,7 @@
                                         Name="ModelCardBottom"
                                         Padding="8"
                                         CornerRadius="0,0,8,8"
-                                        IsHitTestVisible="False">
+                                        IsHitTestVisible="True">
 
                                         <StackPanel>
                                             <Grid ColumnDefinitions="*, Auto">
@@ -664,7 +664,7 @@
                                                 Foreground="{DynamicResource TextFillColorTertiaryBrush}"
                                                 Text="{Binding CheckpointFile.FileName}"
                                                 TextWrapping="NoWrap"
-                                                ToolTip.Tip="{Binding CheckpointFile.FileName}" />
+                                                ToolTip.Tip="{Binding CheckpointFile.RelativePath}" />
 
                                             <TextBlock
                                                 MaxWidth="300"


### PR DESCRIPTION
Fix tooltips not appearing in lower checkpoint information panel
Change Filename tooltip to show relative path