### PR TITLE
Show 'About this version' for CivitAI models

### DIFF
--- a/StabilityMatrix.Avalonia/Languages/Resources.Designer.cs
+++ b/StabilityMatrix.Avalonia/Languages/Resources.Designer.cs
@@ -2154,6 +2154,15 @@ namespace StabilityMatrix.Avalonia.Languages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Model Version Description.
+        /// </summary>
+        public static string Label_ModelVersionDescription {
+            get {
+                return ResourceManager.GetString("Label_ModelVersionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Search models, #tags, or @users.
         /// </summary>
         public static string Label_ModelSearchWatermark {

--- a/StabilityMatrix.Avalonia/Languages/Resources.resx
+++ b/StabilityMatrix.Avalonia/Languages/Resources.resx
@@ -303,6 +303,9 @@
   <data name="Label_ModelDescription" xml:space="preserve">
     <value>Model Description</value>
   </data>
+  <data name="Label_ModelVersionDescription" xml:space="preserve">
+    <value>About this version</value>
+  </data>
   <data name="Label_NewVersionAvailable" xml:space="preserve">
     <value>A new version of Stability Matrix is available!</value>
   </data>

--- a/StabilityMatrix.Avalonia/ViewModels/Dialogs/ModelVersionViewModel.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/Dialogs/ModelVersionViewModel.cs
@@ -10,6 +10,8 @@ namespace StabilityMatrix.Avalonia.ViewModels.Dialogs;
 public partial class ModelVersionViewModel : ObservableObject
 {
     private readonly IModelIndexService modelIndexService;
+    
+    public string VersionDescription { get; set; }
 
     [ObservableProperty]
     private CivitModelVersion modelVersion;
@@ -37,6 +39,9 @@ public partial class ModelVersionViewModel : ObservableObject
             ModelVersion.Files?.Select(file => new CivitFileViewModel(modelIndexService, file))
                 ?? new List<CivitFileViewModel>()
         );
+        
+        VersionDescription =
+            $"""<html><body class="markdown-body">{modelVersion.Description}</body></html>""";
     }
 
     public void RefreshInstallStatus()

--- a/StabilityMatrix.Avalonia/Views/Dialogs/SelectModelVersionDialog.axaml
+++ b/StabilityMatrix.Avalonia/Views/Dialogs/SelectModelVersionDialog.axaml
@@ -24,7 +24,7 @@
         MinHeight="450"
         Margin="8"
         ColumnDefinitions="*,Auto,*"
-        RowDefinitions="Auto, Auto, *, Auto">
+        RowDefinitions="Auto, Auto, *, Auto, Auto">
 
         <Grid.Resources>
             <input:StandardUICommand x:Key="ImportCommand" Command="{Binding Import}" />
@@ -287,8 +287,20 @@
             </ScrollViewer>
         </Expander>
 
-        <StackPanel
+        <Expander
             Grid.Row="3"
+            Grid.Column="0"
+            Grid.ColumnSpan="3"
+            Margin="8,8"
+            ExpandDirection="Down"
+            Header="{x:Static lang:Resources.Label_ModelVersionDescription}">
+            <ScrollViewer MaxHeight="300">
+                <controls:MarkdownViewer Html="{Binding SelectedVersionViewModel.VersionDescription}" />
+            </ScrollViewer>
+        </Expander>
+
+        <StackPanel
+            Grid.Row="4"
             Grid.Column="0"
             Grid.ColumnSpan="3"
             Margin="0,8,0,0"


### PR DESCRIPTION
Added an expander under the Model Description section to display the contents of the 'About this version' block from CivitAI.
This block often includes useful information for this specific version.