### PR TITLE
Fix(Package): Prevent update failures due to symlink conflicts

### DIFF
--- a/StabilityMatrix.Core/Models/Packages/BaseGitPackage.cs
+++ b/StabilityMatrix.Core/Models/Packages/BaseGitPackage.cs
@@ -8,6 +8,7 @@ using StabilityMatrix.Core.Helper;
 using StabilityMatrix.Core.Helper.Cache;
 using StabilityMatrix.Core.Models.Database;
 using StabilityMatrix.Core.Models.FileInterfaces;
+using StabilityMatrix.Core.Models.GlobalConfig;
 using StabilityMatrix.Core.Models.Progress;
 using StabilityMatrix.Core.Processes;
 using StabilityMatrix.Core.Python;
@@ -475,6 +476,23 @@ public abstract class BaseGitPackage : BasePackage
                 IsPrerelease = versionOptions.IsPrerelease
             };
         }
+
+            // Determine the shared folder method to use
+            var sharedFolderMethodToUse = installedPackage.PreferredSharedFolderMethod ?? RecommendedSharedFolderMethod;
+
+            // Temporarily remove symlinks if using Symlink method
+            if (sharedFolderMethodToUse == SharedFolderMethod.Symlink)
+            {
+                if (this.SharedFolders is not null)
+                {
+                    Helper.SharedFolders.RemoveLinksForPackage(this.SharedFolders, new DirectoryPath(installedPackage.FullPath!));
+                }
+
+                if (this.SharedOutputFolders is not null && installedPackage.UseSharedOutputFolder)
+                {
+                    Helper.SharedFolders.RemoveLinksForPackage(this.SharedOutputFolders, new DirectoryPath(installedPackage.FullPath!));
+                }
+            }
 
         // fetch
         progress?.Report(new ProgressReport(-1f, "Fetching data...", isIndeterminate: true));


### PR DESCRIPTION
Issue: #1269

Updates for git-based packages could fail if existing symlinks (e.g., for shared models) conflicted with paths that Git needed to write to during a `pull` or `checkout` operation. This would result in "unable to create file" errors and a non-zero exit code from Git.

This commit addresses the issue by modifying `BaseGitPackage.Update`:
1. Before executing `git fetch`, `git checkout`, or `git pull`, the method now temporarily removes any symlinks within the package's installation directory that are managed by StabilityMatrix (based on the package's `SharedFolders` and `SharedOutputFolders` configurations and the active shared folder method). This is done by removing the links themselves, not their target directories.
2. After the Git operations complete, the existing call to `InstallPackage` ensures that the necessary symlinks are re-established according to the current package configuration.

This approach provides Git with a cleaner working directory for its operations, preventing the errors, while ensuring that StabilityMatrix's symlink structure is correctly restored after the package's underlying repository is updated.