### PR TITLE
HardwareHelper: Add support for mining class NVIDIA GPUs

### DIFF
--- a/StabilityMatrix.Core/Helper/HardwareInfo/HardwareHelper.cs
+++ b/StabilityMatrix.Core/Helper/HardwareInfo/HardwareHelper.cs
@@ -70,7 +70,7 @@ public static partial class HardwareHelper
     [SupportedOSPlatform("linux")]
     private static IEnumerable<GpuInfo> IterGpuInfoLinux()
     {
-        var output = RunBashCommand("lspci | grep VGA");
+        var output = RunBashCommand("lspci | grep -E 'VGA|3D'");
         var gpuLines = output.Split("\n");
 
         var gpuIndex = 0;
@@ -87,10 +87,10 @@ public static partial class HardwareHelper
             string? name = null;
 
             // Parse output with regex
-            var match = Regex.Match(gpuOutput, @"VGA compatible controller: ([^\n]*)");
+            var match = Regex.Match(gpuOutput, @"(VGA compatible controller|3D controller): ([^\n]*)");
             if (match.Success)
             {
-                name = match.Groups[1].Value.Trim();
+                name = match.Groups[2].Value.Trim();
             }
 
             match = Regex.Match(gpuOutput, @"prefetchable\) \[size=(\\d+)M\]");


### PR DESCRIPTION
NVIDIA released multiple crypto mining GPUs between 2017 and 2021, these are fused down and totally unable to do anything aside from compute aka crypto and surprisingly also AI workloads.

However as these GPUs lack any sort of outputs as the display engine is disabled, these GPUs are classed as "3D Controllers" in the PCI database, rendering them not detected by StabilityMatrix.

Add support for them in the HardwareInfo helper.