### PR TITLE
Fix: Linux AppImage update handling for in-app updating.

### DIFF
--- a/StabilityMatrix.Avalonia/ViewModels/Dialogs/UpdateViewModel.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/Dialogs/UpdateViewModel.cs
@@ -170,11 +170,9 @@ public partial class UpdateViewModel : ContentDialogViewModelBase
                 var updateScriptPath = UpdateHelper.UpdateFolder.JoinFile("update_script.sh").FullPath;
                 var newAppImage = UpdateHelper.ExecutablePath.FullPath;
 
-                var scriptContent = $"""
+                var scriptContent = """
 #!/bin/bash
-PID={Environment.ProcessId}
-NEW_APPIMAGE="{newAppImage.Replace("\"", "\\\"")}"
-OLD_APPIMAGE="{appImage.Replace("\"", "\\\"")}"
+set -e
 
 # Wait for the process to exit
 while kill -0 "$PID" 2>/dev/null; do
@@ -196,15 +194,19 @@ disown
                     UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
                 );
 
-                System.Diagnostics.Process.Start(
-                    new System.Diagnostics.ProcessStartInfo
-                    {
-                        FileName = "/usr/bin/env",
-                        Arguments = $"bash \"{updateScriptPath}\"",
-                        UseShellExecute = false,
-                        CreateNoWindow = true,
-                    }
-                );
+                var startInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "/usr/bin/env",
+                    Arguments = $"bash \"{updateScriptPath}\"",
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                };
+
+                startInfo.EnvironmentVariables["PID"] = Environment.ProcessId.ToString();
+                startInfo.EnvironmentVariables["NEW_APPIMAGE"] = newAppImage;
+                startInfo.EnvironmentVariables["OLD_APPIMAGE"] = appImage;
+
+                System.Diagnostics.Process.Start(startInfo);
 
                 App.Shutdown();
                 return;
@@ -214,7 +216,7 @@ disown
                 logger.LogError(ex, "Failed to execute AppImage update script");
 
                 var dialog = DialogHelper.CreateMarkdownDialog(
-                    "AppImage update script failed. \nCould not replace old AppImage with new version. Please check directory permissions. \nFalling back to standard update process. User intervention required: After program closes, \nplease move the new AppImage extracted in the '.StabilityMatrixUpdate' hidden directory to the old AppImage overwriting it. \n\nClose this dialog to continue with standard update process.",
+                    "AppImage update script failed. \nCould not replace old AppImage with new version. Please check directory permissions. \nFalling back to standard update process. User intervention required: \nAfter program closes, \nplease move the new AppImage extracted in the '.StabilityMatrixUpdate' hidden directory to the old AppImage overwriting it. \n\nClose this dialog to continue with standard update process.",
                     Resources.Label_UnexpectedErrorOccurred
                 );
 


### PR DESCRIPTION
Fixing support for seamless self-updating of the application when running as a Linux AppImage. The new logic handles replacing the running AppImage with the updated version, including a fallback and user notification if the automatic update fails. Currently, due to nature of AppImage security and isolation characteristics, Stability Matrix's in-app updater is not able to successfully copy over the new version over the currently existing AppImage. Causing SM to restart as the old version again and not the updated version. This required the user to manually copy the new version out of the '.StabilityMatrixUpdate' hidden directory and overwrite the old one with it.

**Linux AppImage self-update support:**

* Added logic in `UpdateViewModel.cs` to detect when running as an AppImage and, after downloading an update, generate and execute a shell script that waits for the app to exit, replaces the old AppImage with the new one, sets executable permissions, and relaunches the updated AppImage in the background.
* If the script execution fails, logs the error and presents a markdown dialog to the user explaining the manual update steps required, then falls back to the standard update process.