### PR TITLE
Upgrade default Python version to 3.12.10 and add UV-managed Python support

### DIFF
--- a/StabilityMatrix.Avalonia/Assets.cs
+++ b/StabilityMatrix.Avalonia/Assets.cs
@@ -95,6 +95,12 @@ internal static class Assets
     public static IEnumerable<(AvaloniaResource resource, string relativePath)> PyModuleVenv =>
         FindAssets("win-x64/venv/");
 
+    /// <summary>
+    /// Legacy Python 3.10.11 download URL. Kept for backward compatibility with existing
+    /// installations that still use the embedded Python 3.10.11.
+    /// New installations use UV-managed Python (3.12.10+ by default).
+    /// See: https://github.com/LykosAI/StabilityMatrix/issues/1138
+    /// </summary>
     [SupportedOSPlatform("windows")]
     [SupportedOSPlatform("linux")]
     [SupportedOSPlatform("macos")]

--- a/StabilityMatrix.Avalonia/ViewModels/Dialogs/OneClickInstallViewModel.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/Dialogs/OneClickInstallViewModel.cs
@@ -133,7 +133,7 @@ public partial class OneClickInstallViewModel : ContentDialogViewModelBase
             new SetupPrerequisitesStep(
                 prerequisiteHelper,
                 SelectedPackage,
-                PyInstallationManager.Python_3_10_17
+                SelectedPackage.RecommendedPythonVersion
             )
         };
 
@@ -179,7 +179,7 @@ public partial class OneClickInstallViewModel : ContentDialogViewModelBase
             LastUpdateCheck = DateTimeOffset.Now,
             PreferredTorchIndex = torchVersion,
             PreferredSharedFolderMethod = recommendedSharedFolderMethod,
-            PythonVersion = PyInstallationManager.Python_3_10_17.StringValue
+            PythonVersion = SelectedPackage.RecommendedPythonVersion.StringValue
         };
 
         var installStep = new InstallPackageStep(

--- a/StabilityMatrix.Avalonia/ViewModels/Dialogs/PackageImportViewModel.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/Dialogs/PackageImportViewModel.cs
@@ -299,7 +299,7 @@ public partial class PackageImportViewModel(
             PreferredSharedFolderMethod = sharedFolderRecommendation,
             PythonVersion =
                 SelectedPythonVersion?.Version.StringValue
-                ?? PyInstallationManager.Python_3_10_17.StringValue,
+                ?? SelectedBasePackage.RecommendedPythonVersion.StringValue,
         };
 
         // Recreate venv if it's a BaseGitPackage

--- a/StabilityMatrix.Core/Models/InstalledPackage.cs
+++ b/StabilityMatrix.Core/Models/InstalledPackage.cs
@@ -55,7 +55,7 @@ public class InstalledPackage : IJsonOnDeserialized
 
     public List<PipPackageSpecifierOverride>? PipOverrides { get; set; }
 
-    public string PythonVersion { get; set; } = PyInstallationManager.Python_3_10_11.StringValue;
+    public string PythonVersion { get; set; } = PyInstallationManager.DefaultVersion.StringValue;
 
     /// <summary>
     /// Get the launch args host option value.

--- a/StabilityMatrix.Core/Models/PackageModification/InstallSageAttentionStep.cs
+++ b/StabilityMatrix.Core/Models/PackageModification/InstallSageAttentionStep.cs
@@ -228,11 +228,14 @@ public class InstallSageAttentionStep(
     {
         var venvLibsDir = installedPackagePath.JoinDir("venv", "libs");
         var venvIncludeDir = installedPackagePath.JoinDir("venv", "include");
+        // Check for version-specific Python lib (e.g., python312.lib for Python 3.12)
+        var pyVersion = PyVersion.Parse(InstalledPackage.PythonVersion);
+        var pythonLibName = $"python{pyVersion.Major}{pyVersion.Minor}.lib";
         if (
             venvLibsDir.Exists
             && venvIncludeDir.Exists
             && venvLibsDir.JoinFile("python3.lib").Exists
-            && venvLibsDir.JoinFile("python310.lib").Exists
+            && venvLibsDir.JoinFile(pythonLibName).Exists
         )
         {
             return;

--- a/StabilityMatrix.Core/Models/PackagePrerequisite.cs
+++ b/StabilityMatrix.Core/Models/PackagePrerequisite.cs
@@ -4,6 +4,12 @@ public enum PackagePrerequisite
 {
     Python310,
     Python31017,
+
+    /// <summary>
+    /// Python managed via UV - version determined by package's RecommendedPythonVersion.
+    /// This is the preferred prerequisite for new packages, replacing Python310.
+    /// </summary>
+    PythonUvManaged,
     VcRedist,
     Git,
     HipSdk,

--- a/StabilityMatrix.Core/Models/Packages/BasePackage.cs
+++ b/StabilityMatrix.Core/Models/Packages/BasePackage.cs
@@ -60,7 +60,7 @@ public abstract class BasePackage(ISettingsManager settingsManager)
     public virtual bool UsesVenv => true;
     public virtual bool InstallRequiresAdmin => false;
     public virtual string? AdminRequiredReason => null;
-    public virtual PyVersion RecommendedPythonVersion => PyInstallationManager.Python_3_10_17;
+    public virtual PyVersion RecommendedPythonVersion => PyInstallationManager.Python_3_12_10;
 
     /// <summary>
     /// Returns a list of extra commands that can be executed for this package.
@@ -298,7 +298,7 @@ public abstract class BasePackage(ISettingsManager settingsManager)
             : PackageVersionType.GithubRelease | PackageVersionType.Commit;
 
     public virtual IEnumerable<PackagePrerequisite> Prerequisites =>
-        [PackagePrerequisite.Git, PackagePrerequisite.Python310, PackagePrerequisite.VcRedist];
+        [PackagePrerequisite.Git, PackagePrerequisite.PythonUvManaged, PackagePrerequisite.VcRedist];
 
     public abstract Task<DownloadPackageVersionOptions?> GetUpdate(InstalledPackage installedPackage);
 

--- a/StabilityMatrix.Core/Models/Packages/Cogstudio.cs
+++ b/StabilityMatrix.Core/Models/Packages/Cogstudio.cs
@@ -21,6 +21,9 @@ public class Cogstudio(
 {
     public override string Name => "Cogstudio";
     public override string DisplayName { get; set; } = "Cogstudio";
+
+    // Pin to Python 3.10 - uses prebuilt deepspeed cp310 wheel
+    public override PyVersion RecommendedPythonVersion => PyInstallationManager.Python_3_10_17;
     public override string RepositoryName => "CogVideo";
     public override string RepositoryAuthor => "THUDM";
     public override string Author => "pinokiofactory";

--- a/StabilityMatrix.Core/Models/Packages/ForgeNeo.cs
+++ b/StabilityMatrix.Core/Models/Packages/ForgeNeo.cs
@@ -19,4 +19,10 @@ public class ForgeNeo(
     public override string DisplayName { get; set; } = "Stable Diffusion WebUI Forge - Neo";
     public override string MainBranch => "neo";
     public override PackageType PackageType => PackageType.SdInference;
+
+    /// <summary>
+    /// Forge Neo requires Python 3.12+ due to dependencies like audioop-lts.
+    /// See: https://github.com/LykosAI/StabilityMatrix/issues/1138
+    /// </summary>
+    public override PyVersion RecommendedPythonVersion => Python.PyInstallationManager.Python_3_12_10;
 }

--- a/StabilityMatrix.Core/Models/Packages/InvokeAI.cs
+++ b/StabilityMatrix.Core/Models/Packages/InvokeAI.cs
@@ -110,7 +110,7 @@ public class InvokeAI(
     }
 
     public override IEnumerable<PackagePrerequisite> Prerequisites =>
-        [PackagePrerequisite.Python310, PackagePrerequisite.VcRedist, PackagePrerequisite.Git];
+        [PackagePrerequisite.PythonUvManaged, PackagePrerequisite.VcRedist, PackagePrerequisite.Git];
 
     public override Task DownloadPackage(
         string installLocation,

--- a/StabilityMatrix.Core/Models/Packages/Sdfx.cs
+++ b/StabilityMatrix.Core/Models/Packages/Sdfx.cs
@@ -157,7 +157,7 @@ public class Sdfx(
 
     public override IEnumerable<PackagePrerequisite> Prerequisites =>
         [
-            PackagePrerequisite.Python310,
+            PackagePrerequisite.PythonUvManaged,
             PackagePrerequisite.VcRedist,
             PackagePrerequisite.Git,
             PackagePrerequisite.Node,

--- a/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
+++ b/StabilityMatrix.Core/Models/Packages/SimpleSDXL.cs
@@ -22,6 +22,9 @@ public class SimpleSDXL(
     public override string Name => "SimpleSDXL";
     public override string DisplayName { get; set; } = "SimpleSDXL";
     public override string Author => "metercai";
+
+    // Pin to Python 3.10 - uses prebuilt insightface cp310 wheel and older torch (2.3.1)
+    public override PyVersion RecommendedPythonVersion => PyInstallationManager.Python_3_10_17;
     public override string Blurb =>
         "Enhanced version of Fooocus for SDXL, more suitable for Chinese and Cloud. Supports Flux.";
     public override string LicenseUrl => "https://github.com/metercai/SimpleSDXL/blob/SimpleSDXL/LICENSE";

--- a/StabilityMatrix.Core/Models/Packages/StableSwarm.cs
+++ b/StabilityMatrix.Core/Models/Packages/StableSwarm.cs
@@ -185,7 +185,7 @@ public class StableSwarm(
         [
             PackagePrerequisite.Git,
             PackagePrerequisite.Dotnet,
-            PackagePrerequisite.Python310,
+            PackagePrerequisite.PythonUvManaged,
             PackagePrerequisite.VcRedist,
         ];
 

--- a/StabilityMatrix.Core/Models/UnknownInstalledPackage.cs
+++ b/StabilityMatrix.Core/Models/UnknownInstalledPackage.cs
@@ -12,7 +12,7 @@ public class UnknownInstalledPackage : InstalledPackage
             Id = Guid.NewGuid(),
             PackageName = UnknownPackage.Key,
             DisplayName = name,
-            PythonVersion = PyInstallationManager.Python_3_10_17.StringValue,
+            PythonVersion = PyInstallationManager.DefaultVersion.StringValue,
             LibraryPath = $"Packages{System.IO.Path.DirectorySeparatorChar}{name}",
         };
     }

--- a/StabilityMatrix.Core/Python/PyBaseInstall.cs
+++ b/StabilityMatrix.Core/Python/PyBaseInstall.cs
@@ -13,7 +13,7 @@ public class PyBaseInstall(PyInstallation installation)
 
     /// <summary>
     /// Gets a PyBaseInstall instance for the default Python installation.
-    /// This uses the default Python 3.10.16 installation.
+    /// Uses PyInstallationManager.DefaultVersion (currently Python 3.12.10).
     /// </summary>
     public static PyBaseInstall Default => new(new PyInstallation(PyInstallationManager.DefaultVersion));
 

--- a/StabilityMatrix.Core/Python/PyInstallationManager.cs
+++ b/StabilityMatrix.Core/Python/PyInstallationManager.cs
@@ -21,18 +21,22 @@ public class PyInstallationManager(IUvManager uvManager, ISettingsManager settin
     public static readonly PyVersion Python_3_12_10 = new(3, 12, 10);
 
     /// <summary>
-    /// List of preferred/target Python versions StabilityMatrix officially supports.
-    /// UV can be used to fetch these if not present.
+    /// List of legacy Python versions that may still be present from older installations.
+    /// These are kept for backward compatibility and migration purposes.
     /// </summary>
     public static readonly IReadOnlyList<PyVersion> OldVersions = new List<PyVersion>
     {
         Python_3_10_11,
+        Python_3_10_17,
     }.AsReadOnly();
 
     /// <summary>
     /// The default Python version to use if none is specified.
+    /// Updated from 3.10.11 to 3.12.10 to address security vulnerabilities
+    /// in Python 3.10 and compatibility with modern packages (e.g., Forge Neo, ComfyUI).
+    /// See: https://github.com/LykosAI/StabilityMatrix/issues/1138
     /// </summary>
-    public static readonly PyVersion DefaultVersion = Python_3_10_11;
+    public static readonly PyVersion DefaultVersion = Python_3_12_10;
 
     /// <summary>
     /// Gets all discoverable Python installations (legacy and UV-managed).

--- a/StabilityMatrix.Core/Python/PyRunner.cs
+++ b/StabilityMatrix.Core/Python/PyRunner.cs
@@ -34,8 +34,8 @@ public class PyRunner : IPyRunner
     /// </summary>
     public string GetPythonDirName(PyVersion? version = null) =>
         version != null
-            ? $"Python{version.Value.Major}{version.Value.Minor}{version.Value.Micro}"
-            : "Python310"; // Default to 3.10.11 for compatibility
+            ? PyInstallation.GetDirectoryNameForVersion(version.Value)
+            : PyInstallation.GetDirectoryNameForVersion(PyInstallationManager.DefaultVersion);
 
     /// <summary>
     /// Get the Python directory for the given version, or the default version if none specified


### PR DESCRIPTION
## Summary
This PR upgrades the default Python version from 3.10.11 to 3.12.10 and introduces UV-managed Python as the preferred installation method for new packages. This addresses security vulnerabilities in Python 3.10 and improves compatibility with modern packages like Forge Neo and ComfyUI.

## Key Changes

- **Default Python Version**: Updated `PyInstallationManager.DefaultVersion` from Python 3.10.11 to Python 3.12.10
  - Addresses security vulnerabilities in Python 3.10
  - Improves compatibility with modern packages and dependencies
  - Reference: https://github.com/LykosAI/StabilityMatrix/issues/1138

- **New UV-Managed Python Prerequisite**: Added `PackagePrerequisite.PythonUvManaged` enum value
  - Replaces `PackagePrerequisite.Python310` as the preferred installation method
  - Uses the package's `RecommendedPythonVersion` or falls back to the default version
  - Implemented in both `UnixPrerequisiteHelper` and `WindowsPrerequisiteHelper`

- **Prerequisite Helper Updates**:
  - Modified `InstallPackageRequirements()` to handle UV-managed Python installations
  - Updated `InstallAllIfNecessary()` to install the default Python version via UV
  - Added fallback logic for non-legacy Python versions to use UV installation
  - Made `GetPythonDownloadResource()` return nullable to distinguish between legacy and UV-managed versions

- **Package-Specific Python Versions**:
  - `ForgeNeo`: Set to Python 3.12.10 (requires 3.12+ for audioop-lts dependency)
  - `Cogstudio`: Pinned to Python 3.10.17 (uses prebuilt deepspeed cp310 wheel)
  - `SimpleSDXL`: Pinned to Python 3.10.17 (uses prebuilt insightface cp310 wheel and older torch)
  - `BasePackage`: Updated default recommended version to Python 3.12.10
  - `InvokeAI`, `Sdfx`, `StableSwarm`: Updated prerequisites to use `PythonUvManaged`

- **Dynamic Wheel Installation**: Updated `Wan2GP` to dynamically select correct wheel files based on installed Python version (cp310, cp312, etc.)

- **Backward Compatibility**:
  - Legacy Python 3.10.11 support maintained for existing installations
  - `OldVersions` list updated to include both Python 3.10.11 and 3.10.17
  - Direct download URLs still available for legacy versions
  - Comments added throughout to document backward compatibility measures

- **UI Updates**:
  - `OneClickInstallViewModel`: Uses `SelectedPackage.RecommendedPythonVersion` instead of hardcoded Python 3.10.17
  - `PackageImportViewModel`: Falls back to package's recommended version instead of hardcoded version

- **Minor Fixes**:
  - `PyRunner.GetPythonDirName()`: Now uses `PyInstallation.GetDirectoryNameForVersion()` for consistency
  - `InstallSageAttentionStep`: Updated to use version-specific Python lib names (e.g., python312.lib)
  - `InstalledPackage`: Default Python version now uses `PyInstallationManager.DefaultVersion`
  - `UnixPrerequisiteHelper`: Added `GetRelativePythonDllPath()` helper for platform-specific library paths

## Implementation Details

- UV installation is attempted for non-legacy Python versions when no direct download URL is configured
- The system maintains a clear distinction between legacy (directly downloaded) and UV-managed Python installations
- Package prerequisites can now specify UV-managed Python, allowing flexible version selection per package
- Error messages provide clear guidance when Python installation fails

https://claude.ai/code/session_01TtVGKfVzTrGHApA3CEcyLg