### PR TITLE
Fix: [SD.Next] CLIP failing to build due to pkg_resources missing (setuptools)

### DIFF
--- a/StabilityMatrix.Core/Models/Packages/VladAutomatic.cs
+++ b/StabilityMatrix.Core/Models/Packages/VladAutomatic.cs
@@ -312,6 +312,8 @@ public class VladAutomatic(
             )
             .ConfigureAwait(false);
 
+        ApplySetuptoolsConstraints(venvRunner, installLocation);
+
         await venvRunner.PipInstall(["setuptools", "rich", "uv"]).ConfigureAwait(false);
         if (options.PythonOptions.PythonVersion is { Minor: < 12 })
         {
@@ -431,6 +433,8 @@ public class VladAutomatic(
             )
             .ConfigureAwait(false);
 
+        ApplySetuptoolsConstraints(venvRunner, installedPackage.FullPath!.Unwrap());
+
         await venvRunner.CustomInstall("launch.py --upgrade --test", onConsoleOutput).ConfigureAwait(false);
 
         try
@@ -466,6 +470,12 @@ public class VladAutomatic(
         }
 
         return baseUpdateResult;
+    }
+
+    private static void ApplySetuptoolsConstraints(IPyVenvRunner venvRunner, string installLocation)
+    {
+        var constraintPath = Path.Combine(installLocation, "venv", "uv-build-constraints.txt");
+        venvRunner.UpdateEnvironmentVariables(env => env.SetItem("PIP_CONSTRAINT", constraintPath));
     }
 
     private class VladExtensionManager(VladAutomatic package)


### PR DESCRIPTION
Added PIP_CONSTRAINT hook so pip process used for building CLIP inherits the setuptools constraint in UV_BUILD_CONSTRAINT.

This fixes the issue of building of CLIP failing during install due to missing "pkg_resources" module due to it utilizing the latest version of setuptools which has that module removed.