### PR TITLE
Fix: Avoid duplicate pip package entries in results

### DIFF
--- a/StabilityMatrix.Core/Python/PipShowResult.cs
+++ b/StabilityMatrix.Core/Python/PipShowResult.cs
@@ -64,10 +64,20 @@ public record PipShowResult
             linesDict.TryAdd(key, value);
         }
 
+        if (!linesDict.TryGetValue("Name", out var name))
+        {
+            throw new FormatException("The 'Name' key was not found in the pip show output.");
+        }
+
+        if (!linesDict.TryGetValue("Version", out var version))
+        {
+            throw new FormatException("The 'Version' key was not found in the pip show output.");
+        }
+
         return new PipShowResult
         {
-            Name = linesDict["Name"],
-            Version = linesDict["Version"],
+            Name = name,
+            Version = version,
             Summary = linesDict.GetValueOrDefault("Summary"),
             HomePage = linesDict.GetValueOrDefault("Home-page"),
             Author = linesDict.GetValueOrDefault("Author"),

--- a/StabilityMatrix.Tests/Core/PipShowResultsTests.cs
+++ b/StabilityMatrix.Tests/Core/PipShowResultsTests.cs
@@ -174,4 +174,11 @@ public class PipShowResultsTests
         Assert.AreEqual("package-a", result.Name);
         Assert.AreEqual("1.0.0", result.Version);
     }
+
+    [TestMethod]
+    public void TestEmptyInputThrowsFormatException()
+    {
+        var input = "";
+        Assert.ThrowsException<FormatException>(() => PipShowResult.Parse(input));
+    }
 }


### PR DESCRIPTION
Added new test cases to smoke out the issue that at least I was running into. There's a couple hits in existing issues given the trace:
- https://github.com/LykosAI/StabilityMatrix/issues/610
- https://github.com/LykosAI/StabilityMatrix/issues/1397

```powershell
dotnet test StabilityMatrix.Tests --filter "FullyQualifiedName~PipShowResultsTests"
...
StabilityMatrix.Tests test failed with 2 error(s) (2.0s)
    F:\projects\StabilityMatrix\StabilityMatrix.Core\Python\PipShowResult.cs(48): error TESTERROR:
      TestMultiplePackages (13ms): Error Message: Test method StabilityMatrix.Tests.Core.PipShowResultsTests.TestMultiplePackages threw exception:
      System.ArgumentException: An item with the same key has already been added. Key: Name
      Stack Trace:
          at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
         at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
         at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
         at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector)
         at StabilityMatrix.Core.Python.PipShowResult.Parse(String output) in F:\projects\StabilityMatrix\StabilityMatrix.Core\Python\PipShowResult.cs:line 48
         at StabilityMatrix.Tests.Core.PipShowResultsTests.TestMultiplePackages() in F:\projects\StabilityMatrix\StabilityMatrix.Tests\Core\PipShowResultsTests.cs:line 62
         at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
         at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)
    F:\projects\StabilityMatrix\StabilityMatrix.Core\Python\PipShowResult.cs(48): error TESTERROR:
      TestDuplicatePackageNameInOutput (< 1ms): Error Message: Test method StabilityMatrix.Tests.Core.PipShowResultsTests.TestDuplicatePackageNameInOutput threw exception:
      System.ArgumentException: An item with the same key has already been added. Key: Name
      Stack Trace:
          at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
         at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
         at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
         at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector)
         at StabilityMatrix.Core.Python.PipShowResult.Parse(String output) in F:\projects\StabilityMatrix\StabilityMatrix.Core\Python\PipShowResult.cs:line 48
         at StabilityMatrix.Tests.Core.PipShowResultsTests.TestDuplicatePackageNameInOutput() in F:\projects\StabilityMatrix\StabilityMatrix.Tests\Core\PipShowResultsTests.cs:line 171
         at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
         at System.Reflection.MethodBaseInvoker.InvokeWithNoArgs(Object obj, BindingFlags invokeAttr)

Test summary: total: 5, failed: 2, succeeded: 3, skipped: 0, duration: 2.0s
Build failed with 2 error(s) and 394 warning(s) in 51.1s
```

Passes after applying the changes.