### PR TITLE
Fix: Dropdown menu overlayed in Inference UI Model Cards not being scrollable on Linux.

### DIFF
--- a/StabilityMatrix.Avalonia/Controls/FADownloadableComboBox.cs
+++ b/StabilityMatrix.Avalonia/Controls/FADownloadableComboBox.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.DependencyInjection;
 using StabilityMatrix.Avalonia.Services;
 using StabilityMatrix.Avalonia.ViewModels.Base;
 using StabilityMatrix.Avalonia.ViewModels.Dialogs;
+using StabilityMatrix.Core.Helper;
 using StabilityMatrix.Core.Models;
 
 namespace StabilityMatrix.Avalonia.Controls;
@@ -49,6 +50,13 @@ public partial class FADownloadableComboBox : FAComboBox
         var scrollViewer = popupChild.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
 
         if (scrollViewer == null)
+            return;
+
+        // On Unix-like systems, overlay popups share the same TopLevel visual root as the main window.
+        // FAComboBox.OnPopupOpened adds a TopLevel tunnel handler that marks all wheel eventsas handled while the dropdown is open,
+        // which inadvertently blocks scroll-wheelevents in popup menus in Inference model cards.
+        // Resetting e.Handled on the ScrollViewer's tunnel phase counters this.
+        if (!Compat.IsUnix)
             return;
 
         openSubscription = scrollViewer.AddDisposableHandler(


### PR DESCRIPTION
On Linux, FAComboBox popups are rendered as overlay popups that share the same TopLevel visual root as the main window. 

FAComboBox.OnPopupOpened adds a TopLevel tunnel handler that marks ALL pointer-wheel events as handled (when dropdown is open and source.VisualRoot == TopLevel) to prevent parent ScrollViewers from stealing the event. The side-effect is that the popup's own internal ScrollViewer also never receives the event. Causing the dropdown in the Model cards in the Inference UI (HiResFix, Upscaler, etc) to not be able to scroll with the mousewheel, leaving the user to have to click and drag the scroll bar.

Fix: Add a tunnel handler directly on the popup ScrollViewer, which runs after the TopLevel handler in tunnel order, that resets e.Handled = false, allowing the ScrollViewer's normal bubble handler to process the scroll and move the dropdown list.