### PR TITLE
Fix: Model downloads failing on VPN connections (SSL/TLS decrypt error). QoL: Retry button

### DIFF
--- a/StabilityMatrix.Avalonia/ViewModels/Base/PausableProgressItemViewModelBase.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/Base/PausableProgressItemViewModelBase.cs
@@ -14,7 +14,8 @@ public abstract partial class PausableProgressItemViewModelBase : ProgressItemVi
         nameof(IsPaused),
         nameof(IsCompleted),
         nameof(CanPauseResume),
-        nameof(CanCancel)
+        nameof(CanCancel),
+        nameof(CanRetry)
     )]
     private ProgressState state = ProgressState.Inactive;
 
@@ -33,8 +34,19 @@ public abstract partial class PausableProgressItemViewModelBase : ProgressItemVi
     public virtual bool SupportsPauseResume => true;
     public virtual bool SupportsCancel => true;
 
+    /// <summary>
+    /// Override to true in subclasses that support manual retry after failure.
+    /// Defaults to false so unrelated progress item types are never affected.
+    /// </summary>
+    public virtual bool SupportsRetry => false;
+
     public bool CanPauseResume => SupportsPauseResume && !IsCompleted && !IsPending;
     public bool CanCancel => SupportsCancel && !IsCompleted;
+
+    /// <summary>
+    /// True only when this item supports retry AND is in the Failed state.
+    /// </summary>
+    public bool CanRetry => SupportsRetry && State == ProgressState.Failed;
 
     private AsyncRelayCommand? pauseCommand;
     public IAsyncRelayCommand PauseCommand => pauseCommand ??= new AsyncRelayCommand(Pause);
@@ -50,6 +62,11 @@ public abstract partial class PausableProgressItemViewModelBase : ProgressItemVi
     public IAsyncRelayCommand CancelCommand => cancelCommand ??= new AsyncRelayCommand(Cancel);
 
     public virtual Task Cancel() => Task.CompletedTask;
+
+    private AsyncRelayCommand? retryCommand;
+    public IAsyncRelayCommand RetryCommand => retryCommand ??= new AsyncRelayCommand(Retry);
+
+    public virtual Task Retry() => Task.CompletedTask;
 
     [RelayCommand]
     private Task TogglePauseResume()

--- a/StabilityMatrix.Avalonia/ViewModels/Base/PausableProgressItemViewModelBase.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/Base/PausableProgressItemViewModelBase.cs
@@ -15,7 +15,8 @@ public abstract partial class PausableProgressItemViewModelBase : ProgressItemVi
         nameof(IsCompleted),
         nameof(CanPauseResume),
         nameof(CanCancel),
-        nameof(CanRetry)
+        nameof(CanRetry),
+        nameof(CanDismiss)
     )]
     private ProgressState state = ProgressState.Inactive;
 
@@ -40,6 +41,12 @@ public abstract partial class PausableProgressItemViewModelBase : ProgressItemVi
     /// </summary>
     public virtual bool SupportsRetry => false;
 
+    /// <summary>
+    /// Override to true in subclasses that support dismissing a failed item,
+    /// which runs full sidecar cleanup before removing the entry.
+    /// </summary>
+    public virtual bool SupportsDismiss => false;
+
     public bool CanPauseResume => SupportsPauseResume && !IsCompleted && !IsPending;
     public bool CanCancel => SupportsCancel && !IsCompleted;
 
@@ -47,6 +54,11 @@ public abstract partial class PausableProgressItemViewModelBase : ProgressItemVi
     /// True only when this item supports retry AND is in the Failed state.
     /// </summary>
     public bool CanRetry => SupportsRetry && State == ProgressState.Failed;
+
+    /// <summary>
+    /// True only when this item supports dismiss AND is in the Failed state.
+    /// </summary>
+    public bool CanDismiss => SupportsDismiss && State == ProgressState.Failed;
 
     private AsyncRelayCommand? pauseCommand;
     public IAsyncRelayCommand PauseCommand => pauseCommand ??= new AsyncRelayCommand(Pause);
@@ -67,6 +79,11 @@ public abstract partial class PausableProgressItemViewModelBase : ProgressItemVi
     public IAsyncRelayCommand RetryCommand => retryCommand ??= new AsyncRelayCommand(Retry);
 
     public virtual Task Retry() => Task.CompletedTask;
+
+    private AsyncRelayCommand? dismissCommand;
+    public IAsyncRelayCommand DismissCommand => dismissCommand ??= new AsyncRelayCommand(Dismiss);
+
+    public virtual Task Dismiss() => Task.CompletedTask;
 
     [RelayCommand]
     private Task TogglePauseResume()

--- a/StabilityMatrix.Avalonia/ViewModels/Progress/DownloadProgressItemViewModel.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/Progress/DownloadProgressItemViewModel.cs
@@ -76,6 +76,12 @@ public class DownloadProgressItemViewModel : PausableProgressItemViewModelBase
     /// </summary>
     public override bool SupportsRetry => true;
 
+    /// <summary>
+    /// Downloads support dismiss, which cleans up all sidecar files when
+    /// the user discards a failed download without retrying.
+    /// </summary>
+    public override bool SupportsDismiss => true;
+
     /// <inheritdoc />
     public override Task Cancel()
     {
@@ -105,5 +111,14 @@ public class DownloadProgressItemViewModel : PausableProgressItemViewModelBase
     {
         download.ResetAttempts();
         return downloadService.TryRestartDownload(download);
+    }
+
+    /// <inheritdoc />
+    /// Runs full cleanup (temp file + sidecar files) for a failed download the user
+    /// chooses not to retry, then transitions to Cancelled so the service removes it.
+    public override Task Dismiss()
+    {
+        download.Dismiss();
+        return Task.CompletedTask;
     }
 }

--- a/StabilityMatrix.Avalonia/ViewModels/Progress/DownloadProgressItemViewModel.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/Progress/DownloadProgressItemViewModel.cs
@@ -99,10 +99,11 @@ public class DownloadProgressItemViewModel : PausableProgressItemViewModelBase
 
     /// <inheritdoc />
     /// Resets the internal retry counter so the user gets a fresh 3-attempt budget,
-    /// then re-queues the download exactly as if it were being resumed from pause.
+    /// then re-registers the download in the service dictionary (it was removed on
+    /// failure) and resumes it through the normal concurrency queue.
     public override Task Retry()
     {
         download.ResetAttempts();
-        return downloadService.TryResumeDownload(download);
+        return downloadService.TryRestartDownload(download);
     }
 }

--- a/StabilityMatrix.Avalonia/ViewModels/Progress/DownloadProgressItemViewModel.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/Progress/DownloadProgressItemViewModel.cs
@@ -71,6 +71,11 @@ public class DownloadProgressItemViewModel : PausableProgressItemViewModelBase
         }
     }
 
+    /// <summary>
+    /// Downloads support manual retry when they reach the Failed state.
+    /// </summary>
+    public override bool SupportsRetry => true;
+
     /// <inheritdoc />
     public override Task Cancel()
     {
@@ -89,6 +94,15 @@ public class DownloadProgressItemViewModel : PausableProgressItemViewModelBase
     /// <inheritdoc />
     public override Task Resume()
     {
+        return downloadService.TryResumeDownload(download);
+    }
+
+    /// <inheritdoc />
+    /// Resets the internal retry counter so the user gets a fresh 3-attempt budget,
+    /// then re-queues the download exactly as if it were being resumed from pause.
+    public override Task Retry()
+    {
+        download.ResetAttempts();
         return downloadService.TryResumeDownload(download);
     }
 }

--- a/StabilityMatrix.Avalonia/Views/ProgressManagerPage.axaml
+++ b/StabilityMatrix.Avalonia/Views/ProgressManagerPage.axaml
@@ -113,6 +113,15 @@
                                         IsVisible="{Binding CanCancel}">
                                         <ui:SymbolIcon Symbol="Cancel" />
                                     </Button>
+
+                                    <!--  Retry button: only visible when download is in Failed state  -->
+                                    <Button
+                                        Classes="transparent-full"
+                                        Command="{Binding RetryCommand}"
+                                        IsVisible="{Binding CanRetry}"
+                                        ToolTip.Tip="Retry download">
+                                        <ui:SymbolIcon Symbol="ArrowCounterclockwise" />
+                                    </Button>
                                 </StackPanel>
 
                                 <ProgressBar

--- a/StabilityMatrix.Avalonia/Views/ProgressManagerPage.axaml
+++ b/StabilityMatrix.Avalonia/Views/ProgressManagerPage.axaml
@@ -122,6 +122,15 @@
                                         ToolTip.Tip="Retry download">
                                         <ui:SymbolIcon Symbol="Refresh" />
                                     </Button>
+
+                                    <!--  Dismiss button: cleans up sidecar files for failed downloads that won't be retried  -->
+                                    <Button
+                                        Classes="transparent-full"
+                                        Command="{Binding DismissCommand}"
+                                        IsVisible="{Binding CanDismiss}"
+                                        ToolTip.Tip="Dismiss and clean up">
+                                        <ui:SymbolIcon Symbol="Delete" />
+                                    </Button>
                                 </StackPanel>
 
                                 <ProgressBar

--- a/StabilityMatrix.Avalonia/Views/ProgressManagerPage.axaml
+++ b/StabilityMatrix.Avalonia/Views/ProgressManagerPage.axaml
@@ -120,7 +120,7 @@
                                         Command="{Binding RetryCommand}"
                                         IsVisible="{Binding CanRetry}"
                                         ToolTip.Tip="Retry download">
-                                        <ui:SymbolIcon Symbol="ArrowCounterclockwise" />
+                                        <ui:SymbolIcon Symbol="Refresh" />
                                     </Button>
                                 </StackPanel>
 

--- a/StabilityMatrix.Core/Models/TrackedDownload.cs
+++ b/StabilityMatrix.Core/Models/TrackedDownload.cs
@@ -78,6 +78,7 @@ public class TrackedDownload
     [JsonIgnore]
     public Exception? Exception { get; private set; }
 
+    private const int MaxRetryAttempts = 3;
     private int attempts;
     private CancellationTokenSource? retryDelayCancellationTokenSource;
 
@@ -381,7 +382,7 @@ public class TrackedDownload
             // Set the exception
             Exception = task.Exception;
 
-            if (IsTransientNetworkException(Exception) && attempts < 3)
+            if (IsTransientNetworkException(Exception) && attempts < MaxRetryAttempts)
             {
                 attempts++;
                 Logger.Warn(
@@ -397,10 +398,11 @@ public class TrackedDownload
                 var delayMs =
                     (int)Math.Min(2000 * Math.Pow(2, attempts - 1), 30_000) + Random.Shared.Next(-500, 500);
                 Logger.Debug(
-                    "Download {Download} retrying in {Delay}ms (attempt {Attempt}/3)",
+                    "Download {Download} retrying in {Delay}ms (attempt {Attempt}/{MaxAttempts})",
                     FileName,
                     delayMs,
-                    attempts
+                    attempts,
+                    MaxRetryAttempts
                 );
 
                 // Persist Inactive to disk before the delay so a restart during backoff loads it as resumable.

--- a/StabilityMatrix.Core/Models/TrackedDownload.cs
+++ b/StabilityMatrix.Core/Models/TrackedDownload.cs
@@ -423,6 +423,16 @@ public class TrackedDownload
         downloadPauseTokenSource = null;
     }
 
+    /// <summary>
+    /// Resets the internal retry attempt counter back to zero.
+    /// Call this before a user-initiated retry so the download gets
+    /// a fresh budget of automatic retries on the new attempt.
+    /// </summary>
+    public void ResetAttempts()
+    {
+        attempts = 0;
+    }
+
     public void SetDownloadService(IDownloadService service)
     {
         downloadService = service;

--- a/StabilityMatrix.Core/Models/TrackedDownload.cs
+++ b/StabilityMatrix.Core/Models/TrackedDownload.cs
@@ -121,6 +121,13 @@ public class TrackedDownload
         }
     }
 
+    private void CancelRetryDelay()
+    {
+        retryDelayCancellationTokenSource?.Cancel();
+        retryDelayCancellationTokenSource?.Dispose();
+        retryDelayCancellationTokenSource = null;
+    }
+
     private async Task StartDownloadTask(long resumeFromByte, CancellationToken cancellationToken)
     {
         var progress = new Progress<ProgressReport>(OnProgressUpdate);
@@ -187,9 +194,7 @@ public class TrackedDownload
             );
         }
         // Cancel any pending auto-retry delay (defensive: Start() accepts Inactive state).
-        retryDelayCancellationTokenSource?.Cancel();
-        retryDelayCancellationTokenSource?.Dispose();
-        retryDelayCancellationTokenSource = null;
+        CancelRetryDelay();
 
         Logger.Debug("Starting download {Download}", FileName);
 
@@ -209,9 +214,7 @@ public class TrackedDownload
     internal void Resume()
     {
         // Cancel any pending auto-retry delay since we're resuming now.
-        retryDelayCancellationTokenSource?.Cancel();
-        retryDelayCancellationTokenSource?.Dispose();
-        retryDelayCancellationTokenSource = null;
+        CancelRetryDelay();
 
         if (ProgressState != ProgressState.Inactive && ProgressState != ProgressState.Paused)
         {
@@ -249,9 +252,7 @@ public class TrackedDownload
     public void Pause()
     {
         // Cancel any pending auto-retry delay.
-        retryDelayCancellationTokenSource?.Cancel();
-        retryDelayCancellationTokenSource?.Dispose();
-        retryDelayCancellationTokenSource = null;
+        CancelRetryDelay();
 
         if (ProgressState != ProgressState.Working)
         {
@@ -283,9 +284,7 @@ public class TrackedDownload
         }
 
         // Cancel any pending auto-retry delay.
-        retryDelayCancellationTokenSource?.Cancel();
-        retryDelayCancellationTokenSource?.Dispose();
-        retryDelayCancellationTokenSource = null;
+        CancelRetryDelay();
 
         Logger.Debug("Cancelling download {Download}", FileName);
 

--- a/StabilityMatrix.Core/Models/TrackedDownload.cs
+++ b/StabilityMatrix.Core/Models/TrackedDownload.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Security.Authentication;
 using System.Text.Json.Serialization;
 using AsyncAwaitBestPractices;
 using NLog;
@@ -317,6 +318,15 @@ public class TrackedDownload
     }
 
     /// <summary>
+    /// Returns true for transient network/SSL exceptions that are safe to retry.
+    /// </summary>
+    private static bool IsTransientNetworkException(Exception? ex) =>
+        ex is IOException or AuthenticationException
+        || ex?.InnerException is IOException or AuthenticationException
+        || ex is AggregateException ae
+            && ae.InnerExceptions.Any(e => e is IOException or AuthenticationException);
+
+    /// <summary>
     /// Invoked by the task's completion callback
     /// </summary>
     private void OnDownloadTaskCompleted(Task task)
@@ -349,7 +359,7 @@ public class TrackedDownload
             // Set the exception
             Exception = task.Exception;
 
-            if ((Exception is IOException || Exception?.InnerException is IOException) && attempts < 3)
+            if (IsTransientNetworkException(Exception) && attempts < 3)
             {
                 attempts++;
                 Logger.Warn(

--- a/StabilityMatrix.Core/Models/TrackedDownload.cs
+++ b/StabilityMatrix.Core/Models/TrackedDownload.cs
@@ -79,6 +79,7 @@ public class TrackedDownload
     public Exception? Exception { get; private set; }
 
     private int attempts;
+    private CancellationTokenSource? retryDelayCancellationTokenSource;
 
     #region Events
     public event EventHandler<ProgressReport>? ProgressUpdate;
@@ -185,6 +186,11 @@ public class TrackedDownload
                 $"Download state must be inactive or pending to start, not {ProgressState}"
             );
         }
+        // Cancel any pending auto-retry delay (defensive: Start() accepts Inactive state).
+        retryDelayCancellationTokenSource?.Cancel();
+        retryDelayCancellationTokenSource?.Dispose();
+        retryDelayCancellationTokenSource = null;
+
         Logger.Debug("Starting download {Download}", FileName);
 
         EnsureDownloadService();
@@ -202,6 +208,11 @@ public class TrackedDownload
 
     internal void Resume()
     {
+        // Cancel any pending auto-retry delay since we're resuming now.
+        retryDelayCancellationTokenSource?.Cancel();
+        retryDelayCancellationTokenSource?.Dispose();
+        retryDelayCancellationTokenSource = null;
+
         if (ProgressState != ProgressState.Inactive && ProgressState != ProgressState.Paused)
         {
             Logger.Warn(
@@ -209,6 +220,7 @@ public class TrackedDownload
                 FileName,
                 ProgressState
             );
+            return;
         }
         Logger.Debug("Resuming download {Download}", FileName);
 
@@ -236,6 +248,11 @@ public class TrackedDownload
 
     public void Pause()
     {
+        // Cancel any pending auto-retry delay.
+        retryDelayCancellationTokenSource?.Cancel();
+        retryDelayCancellationTokenSource?.Dispose();
+        retryDelayCancellationTokenSource = null;
+
         if (ProgressState != ProgressState.Working)
         {
             Logger.Warn(
@@ -264,6 +281,11 @@ public class TrackedDownload
             );
             return;
         }
+
+        // Cancel any pending auto-retry delay.
+        retryDelayCancellationTokenSource?.Cancel();
+        retryDelayCancellationTokenSource?.Dispose();
+        retryDelayCancellationTokenSource = null;
 
         Logger.Debug("Cancelling download {Download}", FileName);
 
@@ -387,8 +409,21 @@ public class TrackedDownload
                 ProgressState = ProgressState.Inactive;
                 OnProgressStateChanged(ProgressState.Inactive);
 
-                // Fire-and-forget the delayed resume to avoid blocking the task continuation thread.
-                Task.Delay(Math.Max(delayMs, 0)).ContinueWith(_ => Resume()).SafeFireAndForget();
+                // Clean up the completed task resources; Resume() will create new ones.
+                downloadTask = null;
+                downloadCancellationTokenSource = null;
+                downloadPauseTokenSource = null;
+
+                // Schedule the retry with a cancellation token so Cancel/Pause can abort the delay.
+                retryDelayCancellationTokenSource?.Dispose();
+                retryDelayCancellationTokenSource = new CancellationTokenSource();
+                Task.Delay(Math.Max(delayMs, 0), retryDelayCancellationTokenSource.Token)
+                    .ContinueWith(t =>
+                    {
+                        if (t.IsCompletedSuccessfully)
+                            Resume();
+                    })
+                    .SafeFireAndForget();
                 return;
             }
 

--- a/StabilityMatrix.Core/Models/TrackedDownload.cs
+++ b/StabilityMatrix.Core/Models/TrackedDownload.cs
@@ -319,6 +319,10 @@ public class TrackedDownload
 
     /// <summary>
     /// Returns true for transient network/SSL exceptions that are safe to retry.
+    /// Catches direct IOException/AuthenticationException, the same types wrapped as
+    /// InnerException (common AggregateException shape from HttpClient), and any leg
+    /// of a multi-inner AggregateException — covering VPN tunnel resets
+    /// ("Connection reset by peer") and TLS re-key failures (OpenSSL SSL_ERROR_SSL).
     /// </summary>
     private static bool IsTransientNetworkException(Exception? ex) =>
         ex is IOException or AuthenticationException
@@ -369,9 +373,26 @@ public class TrackedDownload
                     attempts
                 );
 
+                // Exponential backoff: 2 s → 4 s → 8 s, capped at 30 s, ±500 ms jitter.
+                // Gives the VPN tunnel time to re-key/re-route before reconnecting,
+                // which prevents the retry from hitting the same torn connection.
+                var delayMs =
+                    (int)Math.Min(2000 * Math.Pow(2, attempts - 1), 30_000) + Random.Shared.Next(-500, 500);
+                Logger.Debug(
+                    "Download {Download} retrying in {Delay}ms (attempt {Attempt}/3)",
+                    FileName,
+                    delayMs,
+                    attempts
+                );
+
+                // Persist Inactive state to disk before the delay so that a restart
+                // during the backoff window loads the download as a resumable entry.
                 OnProgressStateChanging(ProgressState.Inactive);
                 ProgressState = ProgressState.Inactive;
-                Resume();
+                OnProgressStateChanged(ProgressState.Inactive);
+
+                // Fire-and-forget the delayed resume to avoid blocking the task continuation thread.
+                Task.Delay(Math.Max(delayMs, 0)).ContinueWith(_ => Resume()).SafeFireAndForget();
                 return;
             }
 

--- a/StabilityMatrix.Core/Models/TrackedDownload.cs
+++ b/StabilityMatrix.Core/Models/TrackedDownload.cs
@@ -217,7 +217,11 @@ public class TrackedDownload
         // Cancel any pending auto-retry delay since we're resuming now.
         CancelRetryDelay();
 
-        if (ProgressState != ProgressState.Inactive && ProgressState != ProgressState.Paused)
+        if (
+            ProgressState != ProgressState.Inactive
+            && ProgressState != ProgressState.Paused
+            && ProgressState != ProgressState.Pending
+        )
         {
             Logger.Warn(
                 "Attempted to resume download {Download} but it is not paused ({State})",
@@ -272,6 +276,33 @@ public class TrackedDownload
         OnProgressStateChanged(ProgressState);
     }
 
+    /// <summary>
+    /// Cleans up temp file and all sidecar files (e.g. .cm-info.json, preview image)
+    /// for a download that has already failed and will not be retried.
+    /// This transitions the state to <see cref="ProgressState.Cancelled"/> so the
+    /// service removes the tracking entry.
+    /// </summary>
+    public void Dismiss()
+    {
+        if (ProgressState != ProgressState.Failed)
+        {
+            Logger.Warn(
+                "Attempted to dismiss download {Download} but it is not in a failed state ({State})",
+                FileName,
+                ProgressState
+            );
+            return;
+        }
+
+        Logger.Debug("Dismissing failed download {Download}", FileName);
+
+        DoCleanup();
+
+        OnProgressStateChanging(ProgressState.Cancelled);
+        ProgressState = ProgressState.Cancelled;
+        OnProgressStateChanged(ProgressState);
+    }
+
     public void Cancel()
     {
         if (ProgressState is not (ProgressState.Working or ProgressState.Inactive))
@@ -313,9 +344,12 @@ public class TrackedDownload
     }
 
     /// <summary>
-    /// Deletes the temp file and any extra cleanup files
+    /// Deletes the temp file and, optionally, any extra cleanup files (e.g. sidecar metadata).
+    /// Pass <paramref name="includeExtraCleanupFiles"/> as <c>false</c> when the download
+    /// failed but may be retried — sidecar files (.cm-info.json, preview image) should survive
+    /// so a manual retry doesn't need to recreate them.
     /// </summary>
-    private void DoCleanup()
+    private void DoCleanup(bool includeExtraCleanupFiles = true)
     {
         try
         {
@@ -325,6 +359,9 @@ public class TrackedDownload
         {
             Logger.Warn("Failed to delete temp file {TempFile}", TempFileName);
         }
+
+        if (!includeExtraCleanupFiles)
+            return;
 
         foreach (var extraFile in ExtraCleanupFileNames)
         {
@@ -440,10 +477,16 @@ public class TrackedDownload
             ProgressState = ProgressState.Success;
         }
 
-        // For failed or cancelled, delete the temp files
-        if (ProgressState is ProgressState.Failed or ProgressState.Cancelled)
+        // For cancelled, delete the temp file and any sidecar metadata.
+        // For failed, only delete the temp file — sidecar files (.cm-info.json, preview image)
+        // are preserved so a manual retry doesn't need to recreate them.
+        if (ProgressState is ProgressState.Cancelled)
         {
             DoCleanup();
+        }
+        else if (ProgressState is ProgressState.Failed)
+        {
+            DoCleanup(includeExtraCleanupFiles: false);
         }
         // For pause, just do nothing
 

--- a/StabilityMatrix.Core/Models/TrackedDownload.cs
+++ b/StabilityMatrix.Core/Models/TrackedDownload.cs
@@ -318,11 +318,8 @@ public class TrackedDownload
     }
 
     /// <summary>
-    /// Returns true for transient network/SSL exceptions that are safe to retry.
-    /// Catches direct IOException/AuthenticationException, the same types wrapped as
-    /// InnerException (common AggregateException shape from HttpClient), and any leg
-    /// of a multi-inner AggregateException — covering VPN tunnel resets
-    /// ("Connection reset by peer") and TLS re-key failures (OpenSSL SSL_ERROR_SSL).
+    /// Returns true for transient network/SSL exceptions that are safe to retry (ie: VPN tunnel resets or TLS re-key failures)
+    /// (IOException, AuthenticationException, or either wrapped in an AggregateException).
     /// </summary>
     private static bool IsTransientNetworkException(Exception? ex) =>
         ex is IOException or AuthenticationException
@@ -385,8 +382,7 @@ public class TrackedDownload
                     attempts
                 );
 
-                // Persist Inactive state to disk before the delay so that a restart
-                // during the backoff window loads the download as a resumable entry.
+                // Persist Inactive to disk before the delay so a restart during backoff loads it as resumable.
                 OnProgressStateChanging(ProgressState.Inactive);
                 ProgressState = ProgressState.Inactive;
                 OnProgressStateChanged(ProgressState.Inactive);
@@ -424,13 +420,14 @@ public class TrackedDownload
     }
 
     /// <summary>
-    /// Resets the internal retry attempt counter back to zero.
-    /// Call this before a user-initiated retry so the download gets
-    /// a fresh budget of automatic retries on the new attempt.
+    /// Resets the retry counter and silently sets state to Inactive without firing events.
+    /// Must be called before re-adding to TrackedDownloadService to avoid events
+    /// firing while the download is absent from the dictionary.
     /// </summary>
     public void ResetAttempts()
     {
         attempts = 0;
+        ProgressState = ProgressState.Inactive;
     }
 
     public void SetDownloadService(IDownloadService service)

--- a/StabilityMatrix.Core/Services/ITrackedDownloadService.cs
+++ b/StabilityMatrix.Core/Services/ITrackedDownloadService.cs
@@ -15,5 +15,7 @@ public interface ITrackedDownloadService
         NewDownload(new Uri(downloadUrl), downloadPath);
     Task TryStartDownload(TrackedDownload download);
     Task TryResumeDownload(TrackedDownload download);
+    Task TryRestartDownload(TrackedDownload download);
+
     void UpdateMaxConcurrentDownloads(int newMax);
 }

--- a/StabilityMatrix.Core/Services/TrackedDownloadService.cs
+++ b/StabilityMatrix.Core/Services/TrackedDownloadService.cs
@@ -138,13 +138,33 @@ public class TrackedDownloadService : ITrackedDownloadService, IDisposable
         downloadsDir.Create();
         var jsonFile = downloadsDir.JoinFile($"{download.Id}.json");
 
-        var jsonFileStream = jsonFile.Info.Open(FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
-        var json = JsonSerializer.Serialize(download);
-        jsonFileStream.Write(Encoding.UTF8.GetBytes(json));
-        jsonFileStream.Flush();
+        var jsonFileStream = new FileStream(
+            jsonFile.Info.FullName,
+            FileMode.Create,
+            FileAccess.ReadWrite,
+            FileShare.Read,
+            bufferSize: 4096,
+            useAsync: true
+        );
+        var jsonBytes = JsonSerializer.SerializeToUtf8Bytes(download);
 
-        // Handlers are already attached from the original AddDownload call.
-        downloads.TryAdd(download.Id, (download, jsonFileStream));
+        try
+        {
+            await jsonFileStream.WriteAsync(jsonBytes).ConfigureAwait(false);
+            await jsonFileStream.FlushAsync().ConfigureAwait(false);
+
+            // Handlers are already attached from the original AddDownload call.
+            if (!downloads.TryAdd(download.Id, (download, jsonFileStream)))
+            {
+                // Already tracked; discard the newly opened stream.
+                await jsonFileStream.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+        catch
+        {
+            await jsonFileStream.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
 
         await TryResumeDownload(download).ConfigureAwait(false);
     }

--- a/StabilityMatrix.Core/Services/TrackedDownloadService.cs
+++ b/StabilityMatrix.Core/Services/TrackedDownloadService.cs
@@ -245,12 +245,17 @@ public class TrackedDownloadService : ITrackedDownloadService, IDisposable
     /// </summary>
     private void UpdateJsonForDownload(TrackedDownload download)
     {
+        // The download may have already been removed from the dictionary (e.g. it failed and was
+        // then dismissed). In that case there is nothing to persist, so skip silently.
+        if (!downloads.TryGetValue(download.Id, out var downloadInfo))
+            return;
+
         // Serialize to json
         var json = JsonSerializer.Serialize(download);
         var jsonBytes = Encoding.UTF8.GetBytes(json);
 
         // Write to file
-        var (_, fs) = downloads[download.Id];
+        var (_, fs) = downloadInfo;
         fs.Seek(0, SeekOrigin.Begin);
         fs.Write(jsonBytes);
         fs.Flush();

--- a/StabilityMatrix.Core/Services/TrackedDownloadService.cs
+++ b/StabilityMatrix.Core/Services/TrackedDownloadService.cs
@@ -129,6 +129,26 @@ public class TrackedDownloadService : ITrackedDownloadService, IDisposable
         }
     }
 
+    public async Task TryRestartDownload(TrackedDownload download)
+    {
+        // Re-create the backing JSON file and re-add to the dictionary.
+        // Downloads are removed on failure, so this restores the tracking entry
+        // so that subsequent state-change events can persist normally.
+        var downloadsDir = new DirectoryPath(settingsManager.DownloadsDirectory);
+        downloadsDir.Create();
+        var jsonFile = downloadsDir.JoinFile($"{download.Id}.json");
+
+        var jsonFileStream = jsonFile.Info.Open(FileMode.Create, FileAccess.ReadWrite, FileShare.Read);
+        var json = JsonSerializer.Serialize(download);
+        jsonFileStream.Write(Encoding.UTF8.GetBytes(json));
+        jsonFileStream.Flush();
+
+        // Handlers are already attached from the original AddDownload call.
+        downloads.TryAdd(download.Id, (download, jsonFileStream));
+
+        await TryResumeDownload(download).ConfigureAwait(false);
+    }
+
     public async Task TryResumeDownload(TrackedDownload download)
     {
         if (IsQueueEnabled && ActiveDownloads >= MaxConcurrentDownloads)

--- a/StabilityMatrix.Tests/Models/TrackedDownloadTests.cs
+++ b/StabilityMatrix.Tests/Models/TrackedDownloadTests.cs
@@ -1,0 +1,178 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using StabilityMatrix.Core.Models;
+using StabilityMatrix.Core.Models.FileInterfaces;
+using StabilityMatrix.Core.Models.Progress;
+using StabilityMatrix.Core.Services;
+
+namespace StabilityMatrix.Tests.Models;
+
+[TestClass]
+public class TrackedDownloadTests
+{
+    private string tempDir = null!;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        if (Directory.Exists(tempDir))
+            Directory.Delete(tempDir, recursive: true);
+    }
+
+    private TrackedDownload CreateDownload(IDownloadService downloadService)
+    {
+        var download = new TrackedDownload
+        {
+            Id = Guid.NewGuid(),
+            SourceUrl = new Uri("https://example.com/model.safetensors"),
+            DownloadDirectory = new DirectoryPath(tempDir),
+            FileName = "model.safetensors",
+            TempFileName = "model.safetensors.partial",
+        };
+        download.SetDownloadService(downloadService);
+        return download;
+    }
+
+    // Resume() must proceed when the state is Pending (queued resume fix).
+
+    [TestMethod]
+    public async Task Resume_WhileInPendingState_SetsStateToWorking()
+    {
+        // Arrange – download service that blocks forever until cancelled.
+        var downloadService = Substitute.For<IDownloadService>();
+        downloadService
+            .ResumeDownloadToFileAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<long>(),
+                Arg.Any<IProgress<ProgressReport>>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(callInfo =>
+            {
+                var ct = callInfo.Arg<CancellationToken>();
+                return Task.Delay(Timeout.Infinite, ct);
+            });
+
+        var download = CreateDownload(downloadService);
+        download.SetPending(); // Simulate being queued
+
+        // Act
+        download.Resume();
+
+        // Assert – Resume() must not have returned early; state is now Working.
+        Assert.AreEqual(ProgressState.Working, download.ProgressState);
+
+        // Cleanup – cancel and wait for the task to finish.
+        var cancelledTcs = new TaskCompletionSource();
+        download.ProgressStateChanged += (_, state) =>
+        {
+            if (state == ProgressState.Cancelled)
+                cancelledTcs.TrySetResult();
+        };
+        download.Cancel();
+        await cancelledTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    // Sidecar files (.cm-info.json, preview image) must survive a failed
+    // download so a manual retry can succeed without recreating them.
+
+    [TestMethod]
+    public async Task OnFailed_SidecarFilesPreservedForRetry()
+    {
+        // Arrange – create sidecar files that ModelImportService would have written.
+        var sidecarPath = Path.Combine(tempDir, "model.cm-info.json");
+        var previewPath = Path.Combine(tempDir, "model.preview.png");
+        await File.WriteAllTextAsync(sidecarPath, "{}");
+        await File.WriteAllTextAsync(previewPath, "PNG");
+
+        // Download service that immediately throws a non-transient error
+        // (InvalidOperationException is not an IOException/AuthenticationException,
+        //  so it goes straight to Failed without any auto-retry attempts).
+        var downloadService = Substitute.For<IDownloadService>();
+        downloadService
+            .ResumeDownloadToFileAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<long>(),
+                Arg.Any<IProgress<ProgressReport>>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.FromException(new InvalidOperationException("Simulated download error")));
+
+        var download = CreateDownload(downloadService);
+        download.ExtraCleanupFileNames.Add(sidecarPath);
+        download.ExtraCleanupFileNames.Add(previewPath);
+
+        var failedTcs = new TaskCompletionSource();
+        download.ProgressStateChanged += (_, state) =>
+        {
+            if (state == ProgressState.Failed)
+                failedTcs.TrySetResult();
+        };
+
+        // Act
+        download.Start();
+        await failedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Assert – sidecar files must still exist for a potential manual retry.
+        Assert.IsTrue(File.Exists(sidecarPath), ".cm-info.json should be preserved after failure");
+        Assert.IsTrue(File.Exists(previewPath), "Preview image should be preserved after failure");
+    }
+
+    [TestMethod]
+    public async Task OnCancelled_SidecarFilesAreDeleted()
+    {
+        // Sidecar files should still be cleaned up when the user explicitly cancels.
+        var sidecarPath = Path.Combine(tempDir, "model.cm-info.json");
+        var previewPath = Path.Combine(tempDir, "model.preview.png");
+        await File.WriteAllTextAsync(sidecarPath, "{}");
+        await File.WriteAllTextAsync(previewPath, "PNG");
+
+        var downloadService = Substitute.For<IDownloadService>();
+        downloadService
+            .ResumeDownloadToFileAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<long>(),
+                Arg.Any<IProgress<ProgressReport>>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(callInfo =>
+            {
+                var ct = callInfo.Arg<CancellationToken>();
+                return Task.Delay(Timeout.Infinite, ct);
+            });
+
+        var download = CreateDownload(downloadService);
+        download.ExtraCleanupFileNames.Add(sidecarPath);
+        download.ExtraCleanupFileNames.Add(previewPath);
+
+        var cancelledTcs = new TaskCompletionSource();
+        download.ProgressStateChanged += (_, state) =>
+        {
+            if (state == ProgressState.Cancelled)
+                cancelledTcs.TrySetResult();
+        };
+
+        download.Start();
+        download.Cancel();
+        await cancelledTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.IsFalse(File.Exists(sidecarPath), ".cm-info.json should be deleted on cancel");
+        Assert.IsFalse(File.Exists(previewPath), "Preview image should be deleted on cancel");
+    }
+}


### PR DESCRIPTION
This pull request introduces user-facing support for retrying failed model downloads, including UI updates, business logic, and robust handling of transient network errors. The main changes add a "Retry" button to the download manager, implement the underlying retry logic with exponential backoff, and ensure proper state management for retries.

**User-facing and ViewModel changes:**

* Added a `Retry` button to the download manager UI, visible only when a download has failed and retry is supported (`ProgressManagerPage.axaml`).
![retrybutton](https://github.com/user-attachments/assets/31f8303c-4d56-4454-8648-f8d97f003f78)

* Extended `PausableProgressItemViewModelBase` to support retry functionality: added `SupportsRetry`, `CanRetry`, and `RetryCommand` properties/methods, allowing subclasses to define retry logic and expose it to the UI. [[1]](diffhunk://#diff-929492ae5996b950b4f81d558475748c42cb997a651eeb2b912ff67f11659363L17-R18) [[2]](diffhunk://#diff-929492ae5996b950b4f81d558475748c42cb997a651eeb2b912ff67f11659363R37-R50) [[3]](diffhunk://#diff-929492ae5996b950b4f81d558475748c42cb997a651eeb2b912ff67f11659363R66-R70)
* Enabled retry support in `DownloadProgressItemViewModel` and implemented the `Retry` method to reset the attempt counter and re-register the download for retry. [[1]](diffhunk://#diff-3d7d44becb204223c721dd7643782e30e1fbb15204fb8b39f9a2f36d19935d1dR74-R78) [[2]](diffhunk://#diff-3d7d44becb204223c721dd7643782e30e1fbb15204fb8b39f9a2f36d19935d1dR99-R108)

**Core download logic improvements:**

* Added robust detection of transient network/SSL exceptions (including `AuthenticationException`) as retryable, and implemented exponential backoff with jitter for automatic retries—persisting state before delay to ensure resumability. [[1]](diffhunk://#diff-2a229c033461caa591cf171ce67c778245be1793a0030ef336a7abcba5fc9732R2) [[2]](diffhunk://#diff-2a229c033461caa591cf171ce67c778245be1793a0030ef336a7abcba5fc9732R320-R329) [[3]](diffhunk://#diff-2a229c033461caa591cf171ce67c778245be1793a0030ef336a7abcba5fc9732L352-R363) [[4]](diffhunk://#diff-2a229c033461caa591cf171ce67c778245be1793a0030ef336a7abcba5fc9732R373-R391)
* Added `ResetAttempts` method to `TrackedDownload` to allow manual retry to reset the attempt counter and state cleanly.

**Service layer changes:**

* Added `TryRestartDownload` to `ITrackedDownloadService` and its implementation, allowing failed downloads to be re-added to the tracking dictionary and resumed as new retry attempts. [[1]](diffhunk://#diff-e74d45907e88f6a446d382b337109aae18627fccee315d5b3e190276384c7899R18-R19) [[2]](diffhunk://#diff-e8ae81dc904a6fabfa23d642d41f40e58195d09a83a04d58ed490de4104fb5c6R132-R151)

When a user is on a VPN connection, the tunnel connection can be rerouted on the provider's end from time to time, which breaks the TCP download stream for a short period. (Known case with NordVPN and Proton VPN)
When this happens the current logic immediately tries to continue the download before the connection can correct itself and commonly fails through each of the 3 retries in the current logic. Leading to failed download state and user has to go back to Model Browser and manually retry the download all over again. 
This keeps the 3 retries but allows time for the connection to fully reset so the download can properly resume. In the extreme case that it still fails the 3 retries, have added a retry button for QoL instead of having to manually search the model again to restart the download.