### PR TITLE
Update Show method to marshal to UI thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to Stability Matrix will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning 2.0](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased - v2.15.8]
+### Fixed
+- Fixed [#1608](https://github.com/LykosAI/StabilityMatrix/issues/1608) - Crash when cdn fetch fails due to error notification not being shown on UI Thread - thanks to @NeuralFault!
+
 ## v2.15.7
 ### Added
 - Added single-instance window activation signaling so reopening the app restores and focuses the existing desktop window instead of launching a duplicate instance

--- a/StabilityMatrix.Avalonia/Services/NotificationService.cs
+++ b/StabilityMatrix.Avalonia/Services/NotificationService.cs
@@ -41,7 +41,7 @@ public class NotificationService(ILogger<NotificationService> logger, ISettingsM
         notificationManager = new WindowNotificationManager(TopLevel.GetTopLevel(visual))
         {
             Position = position,
-            MaxItems = maxItems
+            MaxItems = maxItems,
         };
     }
 
@@ -50,10 +50,6 @@ public class NotificationService(ILogger<NotificationService> logger, ISettingsM
         // Must marshal to UI thread - WindowNotificationManager requires it
         Dispatcher.UIThread.Invoke(() => notificationManager?.Show(notification));
     }
-    {
-        notificationManager?.Show(notification);
-    }
-}
 
     /// <inheritdoc />
     public Task ShowPersistentAsync(NotificationKey key, DesktopNotifications.Notification notification)
@@ -99,25 +95,23 @@ public class NotificationService(ILogger<NotificationService> logger, ISettingsM
                     // Show app toast
                     if (isPersistent)
                     {
-                        Dispatcher.UIThread.Invoke(
-                            () =>
-                                ShowPersistent(
-                                    notification.Title ?? "",
-                                    notification.Body ?? "",
-                                    key.Level.ToNotificationType()
-                                )
+                        Dispatcher.UIThread.Invoke(() =>
+                            ShowPersistent(
+                                notification.Title ?? "",
+                                notification.Body ?? "",
+                                key.Level.ToNotificationType()
+                            )
                         );
                     }
                     else
                     {
-                        Dispatcher.UIThread.Invoke(
-                            () =>
-                                Show(
-                                    notification.Title ?? "",
-                                    notification.Body ?? "",
-                                    key.Level.ToNotificationType(),
-                                    expiration
-                                )
+                        Dispatcher.UIThread.Invoke(() =>
+                            Show(
+                                notification.Title ?? "",
+                                notification.Body ?? "",
+                                key.Level.ToNotificationType(),
+                                expiration
+                            )
                         );
                     }
                     return;
@@ -135,25 +129,23 @@ public class NotificationService(ILogger<NotificationService> logger, ISettingsM
                 // Show app toast
                 if (isPersistent)
                 {
-                    Dispatcher.UIThread.Invoke(
-                        () =>
-                            ShowPersistent(
-                                notification.Title ?? "",
-                                notification.Body ?? "",
-                                key.Level.ToNotificationType()
-                            )
+                    Dispatcher.UIThread.Invoke(() =>
+                        ShowPersistent(
+                            notification.Title ?? "",
+                            notification.Body ?? "",
+                            key.Level.ToNotificationType()
+                        )
                     );
                 }
                 else
                 {
-                    Dispatcher.UIThread.Invoke(
-                        () =>
-                            Show(
-                                notification.Title ?? "",
-                                notification.Body ?? "",
-                                key.Level.ToNotificationType(),
-                                expiration
-                            )
+                    Dispatcher.UIThread.Invoke(() =>
+                        Show(
+                            notification.Title ?? "",
+                            notification.Body ?? "",
+                            key.Level.ToNotificationType(),
+                            expiration
+                        )
                     );
                 }
 

--- a/StabilityMatrix.Avalonia/Services/NotificationService.cs
+++ b/StabilityMatrix.Avalonia/Services/NotificationService.cs
@@ -45,16 +45,13 @@ public class NotificationService(ILogger<NotificationService> logger, ISettingsM
         };
     }
 
-   public void Show(INotification notification)
-{
-    // Must marshal to UI thread - WindowNotificationManager requires it
-    if (Dispatcher.UIThread.CheckAccess())
+    public void Show(INotification notification)
+    {
+        // Must marshal to UI thread - WindowNotificationManager requires it
+        Dispatcher.UIThread.Invoke(() => notificationManager?.Show(notification));
+    }
     {
         notificationManager?.Show(notification);
-    }
-    else
-    {
-        Dispatcher.UIThread.Post(() => notificationManager?.Show(notification));
     }
 }
 

--- a/StabilityMatrix.Avalonia/Services/NotificationService.cs
+++ b/StabilityMatrix.Avalonia/Services/NotificationService.cs
@@ -45,10 +45,18 @@ public class NotificationService(ILogger<NotificationService> logger, ISettingsM
         };
     }
 
-    public void Show(INotification notification)
+   public void Show(INotification notification)
+{
+    // Must marshal to UI thread - WindowNotificationManager requires it
+    if (Dispatcher.UIThread.CheckAccess())
     {
         notificationManager?.Show(notification);
     }
+    else
+    {
+        Dispatcher.UIThread.Post(() => notificationManager?.Show(notification));
+    }
+}
 
     /// <inheritdoc />
     public Task ShowPersistentAsync(NotificationKey key, DesktopNotifications.Notification notification)

--- a/StabilityMatrix.Core/Models/Packages/InvokeAI.cs
+++ b/StabilityMatrix.Core/Models/Packages/InvokeAI.cs
@@ -53,7 +53,7 @@ public class InvokeAI(
 
     public override Uri PreviewImageUri =>
         new(
-            "https://raw.githubusercontent.com/invoke-ai/InvokeAI/3c17a569ce9203976963c3056526460d59129789/docs/src/content/docs/assets/invoke-webui-canvas.png"
+            "https://raw.githubusercontent.com/invoke-ai/InvokeAI/refs/heads/main/docs-old/assets/canvas_preview.png"
         );
 
     public override IEnumerable<SharedFolderMethod> AvailableSharedFolderMethods =>

--- a/StabilityMatrix.Core/Models/Packages/InvokeAI.cs
+++ b/StabilityMatrix.Core/Models/Packages/InvokeAI.cs
@@ -52,7 +52,9 @@ public class InvokeAI(
     public override PackageDifficulty InstallerSortOrder => PackageDifficulty.Advanced;
 
     public override Uri PreviewImageUri =>
-        new("https://raw.githubusercontent.com/invoke-ai/InvokeAI/main/docs/assets/canvas_preview.png");
+        new(
+            "https://raw.githubusercontent.com/invoke-ai/InvokeAI/3c17a569ce9203976963c3056526460d59129789/docs/src/content/docs/assets/invoke-webui-canvas.png"
+        );
 
     public override IEnumerable<SharedFolderMethod> AvailableSharedFolderMethods =>
         [SharedFolderMethod.None, SharedFolderMethod.Configuration];


### PR DESCRIPTION
Ensure notifications are shown on the UI thread.
Any caller that does notificationService.Show( ) or notificationService.TryAsync( ) from a background thread directly hits WindowNotificationManager.Show which hits line 48 raw with no UI thread marshalling. Leading to unhandled exception in Avalonia and crashes.

This follows the same pattern used by ShowAsyncCore which wraps every toast call in Dispatcher.UIThread.Invoke( ).

Without it, NotificationService.Show(INotification notification) on L48 is called from thread-pool threads (Polly continuations, Task.Run blocks) after HTTP failures exhaust retries and surface a notification.

This patch is in regards to recent reported crashes with SM 2.15.7 which is initialized when the CDN rejects or replies HTTP errors when the new banner notification function attempts to pull the JSON from the server, polly exhausts retries and tries to send a error notification to the in-app notification handler resulting in the above.

Potientially fixing #1608 