### PR TITLE
Feature/fix: Add Play/Pause control to inference generation queue

### DIFF
--- a/StabilityMatrix.Avalonia/ViewModels/Base/InferenceGenerationViewModelBase.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/Base/InferenceGenerationViewModelBase.cs
@@ -80,6 +80,15 @@ public abstract partial class InferenceGenerationViewModelBase
     private bool _isProcessingQueue;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(QueueToggleIcon))]
+    [NotifyPropertyChangedFor(nameof(QueueToggleToolTip))]
+    [property: JsonIgnore]
+    private bool isQueuePaused = true;
+
+    public string QueueToggleIcon => IsQueuePaused ? "fa-solid fa-play" : "fa-solid fa-pause";
+    public string QueueToggleToolTip => IsQueuePaused ? "Start Queue" : "Pause Queue";
+
+    [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(QueueGenerationText))]
     [NotifyPropertyChangedFor(nameof(IsQueueClearable))]
     [property: JsonIgnore]
@@ -95,7 +104,18 @@ public abstract partial class InferenceGenerationViewModelBase
     {
         _generationQueue.Clear();
         QueuedGenerationsCount = 0;
+        IsQueuePaused = true;
         Logger.Info("Generation queue cleared");
+    }
+
+    [RelayCommand]
+    private void ToggleQueueState()
+    {
+        IsQueuePaused = !IsQueuePaused;
+        if (!IsQueuePaused)
+        {
+            ProcessQueueAsync().SafeFireAndForget(ex => Logger.Error(ex, "Error processing generation queue"));
+        }
     }
 
     [RelayCommand]
@@ -106,7 +126,10 @@ public abstract partial class InferenceGenerationViewModelBase
         QueuedGenerationsCount = _generationQueue.Count;
         Logger.Info("Queued generation. Queue size: {QueueSize}", QueuedGenerationsCount);
 
-        ProcessQueueAsync().SafeFireAndForget(ex => Logger.Error(ex, "Error processing generation queue"));
+        if (!IsQueuePaused)
+        {
+            ProcessQueueAsync().SafeFireAndForget(ex => Logger.Error(ex, "Error processing generation queue"));
+        }
     }
 
     private async Task ProcessQueueAsync()
@@ -118,7 +141,7 @@ public abstract partial class InferenceGenerationViewModelBase
 
         try
         {
-            while (_generationQueue.Count > 0)
+            while (_generationQueue.Count > 0 && !IsQueuePaused)
             {
                 // Wait for any active generation to complete before starting the next
                 if (GenerateImageCommand.IsRunning)
@@ -130,8 +153,8 @@ public abstract partial class InferenceGenerationViewModelBase
                     }
                 }
 
-                // Re-check after awaiting — queue may have been cleared
-                if (_generationQueue.Count == 0)
+                // Re-check after awaiting — queue may have been cleared or paused
+                if (_generationQueue.Count == 0 || IsQueuePaused)
                     break;
 
                 // Dequeue and load state on UI thread
@@ -149,6 +172,11 @@ public abstract partial class InferenceGenerationViewModelBase
                 {
                     Logger.Error(ex, "Queued generation failed");
                 }
+            }
+
+            if (_generationQueue.Count == 0)
+            {
+                IsQueuePaused = true;
             }
         }
         finally

--- a/StabilityMatrix.Avalonia/ViewModels/Base/InferenceGenerationViewModelBase.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/Base/InferenceGenerationViewModelBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using AsyncAwaitBestPractices;
 using Avalonia.Controls.Notifications;
 using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ExifLibrary;
 using FluentAvalonia.UI.Controls;
@@ -74,6 +75,87 @@ public abstract partial class InferenceGenerationViewModelBase
 
     [JsonIgnore]
     public IInferenceClientManager ClientManager { get; }
+
+    private readonly List<InferenceProjectDocument> _generationQueue = [];
+    private bool _isProcessingQueue;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(QueueGenerationText))]
+    [NotifyPropertyChangedFor(nameof(IsQueueClearable))]
+    [property: JsonIgnore]
+    private int queuedGenerationsCount;
+
+    public string QueueGenerationText =>
+        QueuedGenerationsCount > 0 ? $"Queue Generation ({QueuedGenerationsCount})" : "Queue Generation";
+
+    public bool IsQueueClearable => QueuedGenerationsCount > 0;
+
+    [RelayCommand]
+    private void ClearQueue()
+    {
+        _generationQueue.Clear();
+        QueuedGenerationsCount = 0;
+        Logger.Info("Generation queue cleared");
+    }
+
+    [RelayCommand]
+    private void QueueGeneration()
+    {
+        var doc = InferenceProjectDocument.FromLoadable(this);
+        _generationQueue.Add(doc);
+        QueuedGenerationsCount = _generationQueue.Count;
+        Logger.Info("Queued generation. Queue size: {QueueSize}", QueuedGenerationsCount);
+
+        ProcessQueueAsync().SafeFireAndForget(ex => Logger.Error(ex, "Error processing generation queue"));
+    }
+
+    private async Task ProcessQueueAsync()
+    {
+        if (_isProcessingQueue)
+            return;
+
+        _isProcessingQueue = true;
+
+        try
+        {
+            while (_generationQueue.Count > 0)
+            {
+                // Wait for any active generation to complete before starting the next
+                if (GenerateImageCommand.IsRunning)
+                {
+                    var executionTask = GenerateImageCommand.ExecutionTask;
+                    if (executionTask is not null)
+                    {
+                        await executionTask;
+                    }
+                }
+
+                // Re-check after awaiting — queue may have been cleared
+                if (_generationQueue.Count == 0)
+                    break;
+
+                // Dequeue and load state on UI thread
+                var nextDoc = _generationQueue[0];
+                _generationQueue.RemoveAt(0);
+                QueuedGenerationsCount = _generationQueue.Count;
+
+                await Dispatcher.UIThread.InvokeAsync(() => LoadStateFromJsonObject(nextDoc.State));
+
+                try
+                {
+                    await GenerateImageCommand.ExecuteAsync(default(GenerateFlags));
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "Queued generation failed");
+                }
+            }
+        }
+        finally
+        {
+            _isProcessingQueue = false;
+        }
+    }
 
     /// <inheritdoc />
     protected InferenceGenerationViewModelBase(

--- a/StabilityMatrix.Avalonia/Views/Inference/InferenceTextToImageView.axaml
+++ b/StabilityMatrix.Avalonia/Views/Inference/InferenceTextToImageView.axaml
@@ -1,4 +1,4 @@
-﻿<dock:DockUserControlBase
+<dock:DockUserControlBase
     x:Class="StabilityMatrix.Avalonia.Views.Inference.InferenceTextToImageView"
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -105,7 +105,7 @@
                                     DataContext="{Binding ElementName=Dock, Path=DataContext}">
                                     <Grid
                                         HorizontalAlignment="Center"
-                                        ColumnDefinitions="Auto,*,Auto"
+                                        ColumnDefinitions="Auto,Auto,Auto,Auto"
                                         RowDefinitions="Auto,*">
                                         <Grid.Styles>
                                             <Style Selector="Button">
@@ -152,9 +152,26 @@
                                             Command="{Binding GenerateImageCancelCommand}"
                                             IsVisible="{Binding GenerateImageCommand.CanBeCanceled}" />
 
+                                        <!--  Queue Generation Button  -->
+                                        <StackPanel Grid.Row="1" Grid.Column="2" Orientation="Horizontal" Margin="4,0,0,0">
+                                            <Button
+                                                MinWidth="130"
+                                                MaxWidth="200"
+                                                HorizontalAlignment="Stretch"
+                                                Command="{Binding QueueGenerationCommand}"
+                                                Content="{Binding QueueGenerationText}" />
+                                            <Button
+                                                Margin="4,0,0,0"
+                                                Padding="12,8"
+                                                icons:Attached.Icon="fa-solid fa-trash"
+                                                ToolTip.Tip="Clear Queue"
+                                                IsVisible="{Binding IsQueueClearable}"
+                                                Command="{Binding ClearQueueCommand}" />
+                                        </StackPanel>
+
                                         <Button
                                             Grid.Row="1"
-                                            Grid.Column="2"
+                                            Grid.Column="3"
                                             Margin="4,0"
                                             Padding="12,8"
                                             HorizontalAlignment="Left"

--- a/StabilityMatrix.Avalonia/Views/Inference/InferenceTextToImageView.axaml
+++ b/StabilityMatrix.Avalonia/Views/Inference/InferenceTextToImageView.axaml
@@ -163,6 +163,13 @@
                                             <Button
                                                 Margin="4,0,0,0"
                                                 Padding="12,8"
+                                                icons:Attached.Icon="{Binding QueueToggleIcon}"
+                                                ToolTip.Tip="{Binding QueueToggleToolTip}"
+                                                IsVisible="{Binding IsQueueClearable}"
+                                                Command="{Binding ToggleQueueStateCommand}" />
+                                            <Button
+                                                Margin="4,0,0,0"
+                                                Padding="12,8"
                                                 icons:Attached.Icon="fa-solid fa-trash"
                                                 ToolTip.Tip="Clear Queue"
                                                 IsVisible="{Binding IsQueueClearable}"

--- a/StabilityMatrix.Avalonia/Views/Inference/InferenceTextToImageView.axaml
+++ b/StabilityMatrix.Avalonia/Views/Inference/InferenceTextToImageView.axaml
@@ -159,7 +159,9 @@
                                                 MaxWidth="200"
                                                 HorizontalAlignment="Stretch"
                                                 Command="{Binding QueueGenerationCommand}"
-                                                Content="{Binding QueueGenerationText}" />
+                                                Content="{Binding QueueGenerationText}"
+                                                HotKey="Shift+Enter"
+                                                ToolTip.Tip="{Binding $self.HotKey}" />
                                             <Button
                                                 Margin="4,0,0,0"
                                                 Padding="12,8"


### PR DESCRIPTION
This commit introduces an explicit Play/Pause toggle to control the execution flow of the generation queue, allowing users to safely stack multiple jobs without inadvertently overwriting their active UI state.

Key changes:
- Added `IsQueuePaused` state and `ToggleQueueStateCommand` to `InferenceGenerationViewModelBase`.
- Modified `ProcessQueueAsync` to respect the paused state and automatically pause when the queue naturally empties.
- Inserted a dynamic Play/Pause button in `InferenceTextToImageView` that reacts to the queue's execution state.
- Updated `ClearQueueCommand` and `QueueGenerationCommand` to enforce the default paused state behavior.

<img width="659" height="140" alt="image" src="https://github.com/user-attachments/assets/e59b3d26-35c3-486b-96ff-3a844eea7237" />