### PR TITLE
Fix: pip requirements handling for environment-marker dependencies

### DIFF
--- a/StabilityMatrix.Core/Processes/ProcessRunner.cs
+++ b/StabilityMatrix.Core/Processes/ProcessRunner.cs
@@ -651,8 +651,15 @@ public static class ProcessRunner
     /// </summary>
     public static string Quote(string argument)
     {
-        var inner = argument.Trim('"');
-        return inner.Contains(' ') ? $"\"{inner}\"" : argument;
+        var inner = argument.Length >= 2 && argument.StartsWith('"') && argument.EndsWith('"')
+            ? argument[1..^1]
+            : argument;
+
+        if (!inner.Contains(' ') && !inner.Contains('"'))
+            return argument;
+
+        var escaped = inner.Replace("\"", "\\\"");
+        return $"\"{escaped}\"";
     }
 
     /// <summary>

--- a/StabilityMatrix.Core/Python/PipInstallArgs.cs
+++ b/StabilityMatrix.Core/Python/PipInstallArgs.cs
@@ -54,7 +54,15 @@ public partial record PipInstallArgs : ProcessArgsBuilder
             requirementsEntries = requirementsEntries.Where(s => !excludeRegex.IsMatch(s));
         }
 
-        return this.AddArgs(requirementsEntries.Select(Argument.Quoted).ToArray());
+        return this.AddArgs(requirementsEntries.Select(ToRequirementArgument).ToArray());
+    }
+
+    private static Argument ToRequirementArgument(string requirementEntry)
+    {
+        if (requirementEntry.StartsWith('-'))
+            return Argument.Quoted(requirementEntry);
+
+        return new Argument(requirementEntry);
     }
 
     /// <summary>

--- a/StabilityMatrix.Tests/Core/PipInstallArgsTests.cs
+++ b/StabilityMatrix.Tests/Core/PipInstallArgsTests.cs
@@ -82,6 +82,26 @@ public class PipInstallArgsTests
     }
 
     [TestMethod]
+    public void TestParsedFromRequirementsTxt_KeepsEnvironmentMarkerRequirementAsSingleArgument()
+    {
+        const string requirements = """
+                                    onnxruntime-gpu==1.22.0; python_version < "3.11"
+                                    """;
+
+        var args = new PipInstallArgs().WithParsedFromRequirementsTxt(requirements).ToProcessArgs();
+
+        Assert.AreEqual(1, args.Count());
+        Assert.AreEqual(
+            "\"onnxruntime-gpu==1.22.0; python_version < \\\"3.11\\\"\"",
+            args.Single().GetQuotedValue()
+        );
+        Assert.AreEqual(
+            "\"onnxruntime-gpu==1.22.0; python_version < \\\"3.11\\\"\"",
+            args.ToString()
+        );
+    }
+
+    [TestMethod]
     public void TestWithUserOverrides()
     {
         // Arrange


### PR DESCRIPTION
This fix resolves a shared Stability Matrix requirements-handling bug that was reported in two places: ComfyUI extension installs on the SM Discord, specifically for the ComfyUI_PuLID_Flux_ll extension, and the Wan2GP install failure I reproduced locally. In both cases, the underlying problem was the same: valid requirements.txt entries containing environment markers were being mangled before they reached uv pip install.

For the ComfyUI extension case, the affected line is the upstream dependency entry:
onnxruntime-gpu; sys_platform != 'darwin' and (platform_machine == 'x86_64' or platform_machine == 'AMD64')

For the Wan2GP case, the affected lines are the upstream Python-version-gated onnxruntime-gpu entries:
onnxruntime-gpu==1.22.0; python_version < "3.11"
and
onnxruntime-gpu==1.25.0.dev20260210001; python_version >= "3.11"

The fix updates Stability Matrix’s shared pip requirements argument handling so environment-marker dependencies are preserved as single install arguments, and corrects command-line quoting so embedded quoted marker values such as "3.11" are escaped properly instead of being stripped or split. Regression tests were added to verify that marker-bearing requirement lines survive both parsing and final command-string generation correctly.