### PR TITLE
ComfyUI-Zluda: Exclude "Enable Manager" launch option from inherited options

### DIFF
--- a/StabilityMatrix.Core/Models/Packages/ComfyZluda.cs
+++ b/StabilityMatrix.Core/Models/Packages/ComfyZluda.cs
@@ -102,7 +102,11 @@ public class ComfyZluda(
                 },
             };
 
-            options.AddRange(base.LaunchOptions.Where(x => x.Name != "Cross Attention Method"));
+            options.AddRange(
+                base.LaunchOptions.Where(x =>
+                    x.Name != "Cross Attention Method" && x.Name != "Enable Manager"
+                )
+            );
             return options;
         }
     }

--- a/StabilityMatrix.Core/Models/Packages/ComfyZluda.cs
+++ b/StabilityMatrix.Core/Models/Packages/ComfyZluda.cs
@@ -104,7 +104,7 @@ public class ComfyZluda(
 
             options.AddRange(
                 base.LaunchOptions.Where(x =>
-                    x.Name != "Cross Attention Method" && x.Name != "Enable Manager"
+                    x.Name != "Cross Attention Method" && !x.Options.Contains("--enable-manager")
                 )
             );
             return options;


### PR DESCRIPTION
This pull request makes a minor adjustment to the launch options for the `ComfyZluda` package. Specifically, it ensures that the "Enable Manager" option, in addition to "Cross Attention Method," is excluded from the inherited launch options.

- Updated `ComfyZluda.LaunchOptions` to filter out both "Cross Attention Method" and "Enable Manager" from the base launch options.

ComfyUI-Zluda installs the custom_node-based version of the comfyui-manager as part of its install process, which requires no launch argument.
But because the ComfyUI configuration it inherits most of its not overidden launch options from uses the new comfyui-manager, its also has --enable-manager being automatically set for zluda installs. This leads to ComfyUI blocking initializing of the node-based one as policy when that launch argument is passed to it. 
Leaving unaware users with broken manager functionality. 