### PR TITLE
ci: use shared org backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,7 +1,7 @@
 name: Automatic Backport
 
 # Label a PR `backport-to-<branch>` to get a cherry-picked PR opened against
-# `<branch>` after merge. Shared implementation:
+# `<branch>` after merge. Shared implementation (and lykos-backport App notes):
 # https://github.com/LykosAI/.github/blob/main/.github/workflows/backport.yml
 
 on:
@@ -16,3 +16,7 @@ permissions:
 jobs:
   backport:
     uses: LykosAI/.github/.github/workflows/backport.yml@main
+    # Passes org var BACKPORT_APP_ID + secret BACKPORT_APP_PRIVATE_KEY through
+    # to the reusable workflow so backport PRs get the lykos-backport App
+    # identity and trigger CI. Harmless (falls back to GITHUB_TOKEN) if unset.
+    secrets: inherit

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,44 +1,18 @@
 name: Automatic Backport
 
+# Label a PR `backport-to-<branch>` to get a cherry-picked PR opened against
+# `<branch>` after merge. Shared implementation:
+# https://github.com/LykosAI/.github/blob/main/.github/workflows/backport.yml
+
 on:
   pull_request:
-    types: ["closed", "labeled"]
+    types: [closed, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
 
 jobs:
   backport:
-    if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'backport-to-main') == true) }}
-    name: Backport PR
-    runs-on: ubuntu-latest
-    steps:
-      # Get the merge target branch to decide mainline number
-      # git cherry-pick mainline is 1 for merge to 'dev', else 2
-      - name: Get target branch
-        run: echo "CP_MAINLINE=$(if [ '${{ github.event.pull_request.base.ref }}' == 'dev' ]; then echo 1; else echo 2; fi)" >> $GITHUB_ENV
-
-      - name: Write json
-        id: create-json
-        uses: jsdaniell/create-json@v1.2.3
-        with:
-          name: ".backportrc.json"
-          json: |
-            {
-              "targetPRLabels": ["backport"],
-              "mainline": ${{ env.CP_MAINLINE }},
-              "commitConflicts": "true",
-              "prTitle": "[{{sourceBranch}} to {{targetBranch}}] backport: {{sourcePullRequest.title}} ({{sourcePullRequest.number}})"
-            }
-
-      - name: Backport Action
-        uses: sorenlouv/backport-github-action@v9.5.1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          auto_backport_label_prefix: backport-to-
-
-      - name: Info log
-        if: ${{ success() }}
-        run: cat ~/.backport/backport.info.log
-
-      - name: Debug log
-        if: ${{ failure() }}
-        run: cat ~/.backport/backport.debug.log        
-          
+    uses: LykosAI/.github/.github/workflows/backport.yml@main


### PR DESCRIPTION
Swaps the bespoke backport workflow for a thin caller of the new reusable workflow in [LykosAI/.github#1](https://github.com/LykosAI/.github/pull/1) (**merge that first** — this references it `@main`).

## Current state worth knowing

The backport flow here is **dormant**: the `dev` branch is gone, and the repo currently has no `backport`/`backport-to-*` labels, so the old workflow hasn't had anything to do for a while. This PR keeps the capability alive at near-zero maintenance cost — recreate a `backport-to-<branch>` label (e.g. for release-branch hotfix backports) and it works again.

## Behavior notes

- `mainline` is now `1` unconditionally (the base-branch parent of a GitHub merge commit, correct for any base branch). The old `1 if dev else 2` came from a trial-and-error fix ("Fix mainline maybe") and its `else 2` path was never exercised — it would have produced wrong cherry-picks if hit.
- `.backportrc.json` is kept: CI never read it (the workflow generates its own config in the workspace), but it still configures local `backport` CLI runs. Its `sourceBranch: dev` is stale for local use — happy to update or drop it if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)