### PR TITLE
docs: add root index.html fallback so SWA deploy validation passes

### DIFF
--- a/docs/public/index.html
+++ b/docs/public/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <!--
+      Root landing fallback. On Azure SWA the "/" route in staticwebapp.config.json
+      302s to /stability-matrix/ before this file is ever served; this page exists
+      because the SWA deploy action requires an index.html at the app root, and it
+      doubles as the redirect for local preview (which has no SWA routing). Replaced
+      by a real product landing page when the site goes multi-product.
+    -->
+    <meta http-equiv="refresh" content="0; url=/stability-matrix/" />
+    <link rel="canonical" href="https://docs.lykos.ai/stability-matrix/" />
+    <title>Lykos Docs</title>
+  </head>
+  <body>
+    <p>Redirecting to the <a href="/stability-matrix/">Stability Matrix documentation</a>&hellip;</p>
+  </body>
+</html>


### PR DESCRIPTION
## What

Fixes the failed first deploy of docs.lykos.ai ([run](https://github.com/LykosAI/StabilityMatrix/actions)): `Azure/static-web-apps-deploy` requires a default file (`index.html`) at the app root, and the `/stability-matrix/` URL prefix (#1676) left the dist root with only assets + the prefixed tree.

- Adds `docs/public/index.html` — copied verbatim to the dist root by VitePress, satisfying the deploy validation.
- The page is a meta-refresh → `/stability-matrix/` with a canonical link, acting as the redirect on hosts without SWA routing (bonus: bare `localhost:4173/` now works in local preview). On Azure the existing `"/"` 302 route in `staticwebapp.config.json` is evaluated before static content, so production behavior is unchanged.
- Gets replaced by a real product landing page when the site goes multi-product.

Verified: `vitepress build` clean, `dist/index.html` + `dist/staticwebapp.config.json` both present, root redirect exercised in local preview.

Merging this (docs/** push to main) triggers the deploy workflow again — no manual re-run needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)