### PR TITLE
Fix: [Activity View] Clear Finished no longer removes failed items that still have retry/dismiss actions

### DIFF
--- a/StabilityMatrix.Avalonia/ViewModels/Base/PausableProgressItemViewModelBase.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/Base/PausableProgressItemViewModelBase.cs
@@ -32,6 +32,13 @@ public abstract partial class PausableProgressItemViewModelBase : ProgressItemVi
     public override bool IsCompleted =>
         State is ProgressState.Success or ProgressState.Failed or ProgressState.Cancelled;
 
+    /// <summary>
+    /// Whether the item should be removed by a "Clear Finished" bulk operation.
+    /// Unlike <see cref="IsCompleted"/>, this excludes <see cref="ProgressState.Failed"/>
+    /// so that items with retry/dismiss buttons remain visible.
+    /// </summary>
+    public override bool IsClearable => State is ProgressState.Success or ProgressState.Cancelled;
+
     public virtual bool SupportsPauseResume => true;
     public virtual bool SupportsCancel => true;
 

--- a/StabilityMatrix.Avalonia/ViewModels/Base/ProgressItemViewModelBase.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/Base/ProgressItemViewModelBase.cs
@@ -16,5 +16,7 @@ public abstract partial class ProgressItemViewModelBase : ViewModelBase
 
     public virtual bool IsCompleted => Progress.Value >= 100 || Failed;
 
+    public virtual bool IsClearable => Progress.Value >= 100 && !Failed;
+
     public ContentDialogProgressViewModelBase Progress { get; init; } = new();
 }

--- a/StabilityMatrix.Avalonia/ViewModels/Progress/ProgressManagerViewModel.cs
+++ b/StabilityMatrix.Avalonia/ViewModels/Progress/ProgressManagerViewModel.cs
@@ -401,7 +401,7 @@ public partial class ProgressManagerViewModel : PageViewModelBase
 
     public void ClearDownloads()
     {
-        ProgressItems.RemoveAll(ProgressItems.Where(x => x.IsCompleted));
+        ProgressItems.RemoveAll(ProgressItems.Where(x => x.IsClearable));
     }
 
     private void OnProgressChanged(object? sender, ProgressItem e)


### PR DESCRIPTION
Clicking **"Clear Finished"** in the Progress Manager would remove *all* items in a terminal state, including **failed downloads**. Failed downloads have a visible **retry button** (and a dismiss button), but the bulk clear wiped them out before the user could act on them.

The root cause was that `ClearDownloads()` filtered on `IsCompleted`, which — correctly for UI purposes — treats `Failed` as a terminal state alongside `Success` and `Cancelled`. But that same property was also used as the sole gate for the bulk-clear operation, conflating "this item is done rendering progress UI" with "this item is safe to discard."

### Fix

Introduced a new `IsClearable` virtual property, parallel to `IsCompleted`, that separates the two concerns:

| Property | Purpose | `Failed` included? |
|----------|---------|-------------------|
| `IsCompleted` | Hide progress spinners, pause/cancel controls | ✅ Yes |
| `IsClearable` | Bulk "Clear Finished" removal | ❌ No |

- **`ProgressItemViewModelBase.IsClearable`** → `Progress.Value >= 100 && !Failed`
- **`PausableProgressItemViewModelBase.IsClearable`** → `State is Success or Cancelled` (failed downloads with retry/dismiss are preserved)
- **`ClearDownloads()`** → now filters on `IsClearable` instead of `IsCompleted`

Cancelled downloads are still cleared (they have no retry path). `IsCompleted` behavior is completely unchanged.

Passed functional test via forced 'Failed' download which remained after bulk clear invoked.