### PR TITLE
Fix launch mode option formatting for SwarmUI

### DIFF
--- a/StabilityMatrix.Core/Models/Packages/StableSwarm.cs
+++ b/StabilityMatrix.Core/Models/Packages/StableSwarm.cs
@@ -128,7 +128,7 @@ public class StableSwarm(
             {
                 Name = "Launch Mode",
                 Type = LaunchOptionType.Bool,
-                Options = ["--launch_mode web", "--launch_mode webinstall"],
+                Options = ["--launch_mode none", "--launch_mode web", "--launch_mode webinstall"],
             },
             LaunchOptionDefinition.Extras,
         ];

--- a/StabilityMatrix.Core/Models/Packages/StableSwarm.cs
+++ b/StabilityMatrix.Core/Models/Packages/StableSwarm.cs
@@ -128,7 +128,7 @@ public class StableSwarm(
             {
                 Name = "Launch Mode",
                 Type = LaunchOptionType.Bool,
-                Options = ["--launch-mode web", "--launch-mode webinstall"],
+                Options = ["--launch_mode web", "--launch_mode webinstall"],
             },
             LaunchOptionDefinition.Extras,
         ];


### PR DESCRIPTION
Underscores are used in the launch args in upstream.
Also added 'none' as an optional '--launch_mode' arg that disables auto web browser launching.