### PR TITLE
Fix: Add bundled uv to PATH for Linux/macOS package launches

### DIFF
--- a/StabilityMatrix.Core/Python/UvVenvRunner.cs
+++ b/StabilityMatrix.Core/Python/UvVenvRunner.cs
@@ -577,12 +577,14 @@ public class UvVenvRunner : IPyVenvRunner
         // Disable pip caching - uses significant memory for large packages like torch
         // env["PIP_NO_CACHE_DIR"] = "true";
 
+        // Add bundled uv to PATH so package launch scripts can invoke `uv`
+        var uvFolder = GlobalConfig.LibraryDir.JoinDir("Assets", "uv");
+
         // On windows, add portable git to PATH and binary as GIT
         if (Compat.IsWindows)
         {
             var portableGitBin = GlobalConfig.LibraryDir.JoinDir("PortableGit", "bin");
             var venvBin = RootPath.JoinDir(RelativeBinPath);
-            var uvFolder = GlobalConfig.LibraryDir.JoinDir("Assets", "uv");
             if (env.TryGetValue("PATH", out var pathValue))
             {
                 env = env.SetItem(
@@ -600,11 +602,11 @@ public class UvVenvRunner : IPyVenvRunner
         {
             if (env.TryGetValue("PATH", out var pathValue))
             {
-                env = env.SetItem("PATH", Compat.GetEnvPathWithExtensions(pathValue));
+                env = env.SetItem("PATH", Compat.GetEnvPathWithExtensions(uvFolder, pathValue));
             }
             else
             {
-                env = env.SetItem("PATH", Compat.GetEnvPathWithExtensions());
+                env = env.SetItem("PATH", Compat.GetEnvPathWithExtensions(uvFolder));
             }
         }
 


### PR DESCRIPTION
The bundled UV currently does not get passed to package launches on Linux/MacOS installs, just on Windows.
This leads to WebUI packages not being able to utilize UV if required/attempted when the user does not have a system-wide UV installed in their OS, or otherwise added to PATH by the user.

This is currently causing Forge Neo installs to fail on Linux with 'Error: 2  uv not found'.

This fix applies the SM bundled UV to be passed to package launches regardless of OS env path. While keeping the PortableGit path specific to Windows installs.

Potentially fixes #1713 as Forge Neo is very uv-dependent and the package config for forge-neo in the project by default launches Neo with --uv extended from ForgeClassic.cs: ```var launchArgs = new List<string> { "launch.py", "--uv", "--exit" }``` which runs Neo's launch process through its UV path in `modules_forge/uv_hook.py` which requires UV to be on PATH. User may have had UV installed system-wide but still cascaded to failure.