### PR TITLE
Fix: Pin OneTrainer ROCm bitsandbytes wheel to 0.49.1

### DIFF
--- a/StabilityMatrix.Core/Models/Rocm/OneTrainerWindowsRocmProfile.cs
+++ b/StabilityMatrix.Core/Models/Rocm/OneTrainerWindowsRocmProfile.cs
@@ -16,7 +16,7 @@ public class OneTrainerWindowsRocmProfile : RocmPackageProfile
 
     // Replace upstream bitsandbytes with ROCm-aware bitsandbytes for ROCm Technical Preview on Windows
     private const string BitsAndBytesWheelUrl =
-        "https://github.com/0xDELUXA/bitsandbytes_win_rocm/releases/download/0.50.0.dev0-py3.12-rocm7.15-win_amd64_all/bitsandbytes-0.50.0.dev0-cp312-cp312-win_amd64.whl";
+        "https://github.com/0xDELUXA/bitsandbytes_win_rocm/releases/download/0.49.1-py3.12-rocm7.16-win_amd64_all/bitsandbytes-0.49.1-cp312-cp312-win_amd64.whl";
 
     public static RocmPackageProfile CreateInstallProfile(PyVersion pyVersion)
     {


### PR DESCRIPTION
Fixes #1708.

Points `OneTrainerWindowsRocmProfile` at the `0.49.1` wheel built for HIP 7.13-7.16, replacing the `0.50.0.dev0`.

The profile currently installs a `0.50` wheel, but OneTrainer pins `bitsandbytes==0.49.1` and passes `block_wise=` and `percentile_clipping=` to every bnb optimizer. `0.50` removed both arguments, so any training run using `AdamW8bit` and friends dies at startup with a `TypeError`. Upstream OneTrainer is not moving to `0.50` for now (Nerogar/OneTrainer#1708 was closed), so matching the pin is the fix.

The wheel covers 27 gfx targets. Verified on Windows with HIP 7.16: 4-bit linear, 8-bit linear and an 8-bit optimizer step all run, and the version now matches OneTrainer's pin exactly so pip has nothing to resolve.

cc @NeuralFault