### PR TITLE
Fix: (Ai-Toolkit) Modify GetEnvVars to support Python version handling

### DIFF
--- a/StabilityMatrix.Core/Models/Packages/AiToolkit.cs
+++ b/StabilityMatrix.Core/Models/Packages/AiToolkit.cs
@@ -199,13 +199,18 @@ public class AiToolkit(
         npmProcess = null;
     }
 
-    private ImmutableDictionary<string, string> GetEnvVars(ImmutableDictionary<string, string> env)
+    private ImmutableDictionary<string, string> GetEnvVars(ImmutableDictionary<string, string> env, PyVersion pythonVersion)
     {
         // Keep distutils importable for setuptools-based builds and training jobs. Must be
         // "local" (setuptools' bundled copy): any other value falls back to stdlib distutils,
         // which no longer exists on Python 3.12+ and breaks source builds (e.g. the pinned
         // diffusers git commit in ai-toolkit's requirements).
-        env = env.SetItem("SETUPTOOLS_USE_DISTUTILS", "local");
+        // An older pre-2.16.3 pre-existing install may still run 3.11, where stdlib distutils
+        // is present and "local" re-arms the _distutils_hack shim, which crashes
+        // when pip loads before setuptools (pypa/setuptools#3621). See StabilityMatrix #1725.
+        // Use "stdlib" on Python < 3.12 and "local" on 3.12+, based on the venv's real version.
+        var useLocalDistutils = pythonVersion >= new PyVersion(3, 12, 0);
+        env = env.SetItem("SETUPTOOLS_USE_DISTUTILS", useLocalDistutils ? "local" : "stdlib");
 
         var pathBuilder = new EnvPathBuilder();
 

--- a/StabilityMatrix.Core/Models/Packages/AiToolkit.cs
+++ b/StabilityMatrix.Core/Models/Packages/AiToolkit.cs
@@ -80,7 +80,7 @@ public class AiToolkit(
                 pythonVersion: options.PythonOptions.PythonVersion
             )
             .ConfigureAwait(false);
-        venvRunner.UpdateEnvironmentVariables(GetEnvVars);
+        venvRunner.UpdateEnvironmentVariables(env => GetEnvVars(env, venvRunner.Version));
 
         var isLegacyNvidia =
             SettingsManager.Settings.PreferredGpu?.IsLegacyNvidiaGpu() ?? HardwareHelper.HasLegacyNvidiaGpu();
@@ -117,7 +117,7 @@ public class AiToolkit(
         progress?.Report(new ProgressReport(-1f, "Installing AI Toolkit UI...", isIndeterminate: true));
 
         var uiDirectory = new DirectoryPath(installLocation, "ui");
-        var envVars = GetEnvVars(venvRunner.EnvironmentVariables);
+        var envVars = GetEnvVars(venvRunner.EnvironmentVariables, venvRunner.Version);
         await PrerequisiteHelper
             .RunNpm("install", uiDirectory, progress?.AsProcessOutputHandler(), envVars)
             .ConfigureAwait(false);
@@ -139,7 +139,7 @@ public class AiToolkit(
     {
         await SetupVenv(installLocation, pythonVersion: PyVersion.Parse(installedPackage.PythonVersion))
             .ConfigureAwait(false);
-        VenvRunner.UpdateEnvironmentVariables(GetEnvVars);
+        VenvRunner.UpdateEnvironmentVariables(env => GetEnvVars(env, VenvRunner.Version));
 
         if (await WarnIfNvidiaDriverBelowCu130MinimumAsync(VenvRunner, onConsoleOutput).ConfigureAwait(false))
         {
@@ -147,7 +147,7 @@ public class AiToolkit(
         }
 
         var uiDirectory = new DirectoryPath(installLocation, "ui");
-        var envVars = GetEnvVars(VenvRunner.EnvironmentVariables);
+        var envVars = GetEnvVars(VenvRunner.EnvironmentVariables, VenvRunner.Version);
         npmProcess = PrerequisiteHelper.RunNpmDetached(
             "run start",
             uiDirectory,


### PR DESCRIPTION
Allows "stdlib" instead of "local" envar on package installs that have existed pre-2.16.3 of StabilityMatrix using Python 3.11, instead of crashing the install for users still using it and have not reinstalled.

While the simple solution is for the user to just reinstall, affected users may not be aware and misappropriate the cause or lead to confusion.

Fixes #1725