### PR TITLE
docs: derive release-notes nav from the release-notes directory

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,4 +1,16 @@
+import { readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vitepress'
+
+// Release-notes nav derives from the files in docs/release-notes/ so adding a
+// page is enough — no second place to update (newest first).
+const releaseNotes = readdirSync(
+  join(dirname(fileURLToPath(import.meta.url)), '..', 'release-notes')
+)
+  .filter((f) => /^\d+\.\d+\.\d+\.md$/.test(f))
+  .map((f) => f.replace(/\.md$/, ''))
+  .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))
 
 export default defineConfig({
   title: 'Stability Matrix Docs',
@@ -86,7 +98,7 @@ export default defineConfig({
       { text: 'Advanced', link: '/stability-matrix/advanced/overview' },
       { text: 'Tips and Tricks', link: '/stability-matrix/tips/overview' },
       { text: 'Troubleshooting', link: '/stability-matrix/troubleshooting/common-issues' },
-      { text: 'Release Notes', link: '/stability-matrix/release-notes/2.16.2' }
+      { text: 'Release Notes', link: `/stability-matrix/release-notes/${releaseNotes[0]}` }
     ],
 
     sidebar: {
@@ -150,9 +162,10 @@ export default defineConfig({
       '/stability-matrix/release-notes/': [
         {
           text: 'Release Notes',
-          items: [
-            { text: 'v2.16.2', link: '/stability-matrix/release-notes/2.16.2' }
-          ]
+          items: releaseNotes.map((v) => ({
+            text: `v${v}`,
+            link: `/stability-matrix/release-notes/${v}`
+          }))
         }
       ]
     },


### PR DESCRIPTION
## Summary
Follow-up to #1730: the 2.16.3 technical notes page deployed fine but was unreachable — the site nav's **Release Notes** link and the sidebar's page list both hardcoded `2.16.2`.

Rather than bump two hardcoded strings per release (the drift that just bit us), both now derive from the files in `docs/release-notes/` at build time, newest first. Adding a release's markdown page is the whole job; the nav can't lag again.

- Nav **Release Notes** entry → newest version in the directory
- Sidebar → all versions, descending
- Filename filter is strict (`N.N.N.md`) so stray files can't leak into nav

This also makes the release-checklist step suggested in #1730 unnecessary for the nav specifically — the remaining checklist item is just "write the page."

🤖 Generated with [Claude Code](https://claude.com/claude-code)