### PR TITLE
Update Windows ROCm Python package index URLs to ROCm 10

### DIFF
--- a/StabilityMatrix.Core/Models/Rocm/WindowsRocmSupport.cs
+++ b/StabilityMatrix.Core/Models/Rocm/WindowsRocmSupport.cs
@@ -8,9 +8,8 @@ namespace StabilityMatrix.Core.Models.Rocm;
 /// </summary>
 public static class WindowsRocmSupport
 {
-    public const string StableMultiArchPythonPackageIndexUrl = "https://repo.amd.com/rocm/whl-multi-arch/";
-    public const string NightlyMultiArchPythonPackageIndexUrl =
-        "https://rocm.nightlies.amd.com/whl-multi-arch/";
+    public const string StableMultiArchPythonPackageIndexUrl = "https://stable.repo.amd.com/rocm/whl-next/";
+    public const string NightlyMultiArchPythonPackageIndexUrl = "https://nightly.repo.amd.com/rocm/whl-next/";
 
     // Used to exclude modern gfxarches from AOTriton activation EnVar as AOTriton does not currently support them.
     // This is a temporary measure until AOTriton adds support for these architectures.


### PR DESCRIPTION
Fast tracking update to new permanent AMD Stable/Nightly repository before other in-progress upcoming changes to ROCm handling to fix an issue regarding 7.14.1 ROCm/PyTorch AMD builds. Users on Stability Matrix discord have been reporting issues with `CUDA error: invalid argument` and `hipErrorInvalidValue` in workflows since the patch version bump from ROCm 7.14 to 7.14.1 that coincided with the release of ROCm 10. This has also been observed outside of Stability Matrix.

Changes:

(ROCm 7.14.1) https://repo.amd.com/rocm/whl-multi-arch/ -> https://stable.repo.amd.com/rocm/whl-next/ (ROCm 10.0)

https://rocm.nightlies.amd.com/whl-multi-arch/ -> https://nightly.repo.amd.com/rocm/whl-next/

Users with pre-existing packages bearing 7.14.1 in it's installation will need to either install a new installation of the package and delete the original, or initiate a package update where the PyTorch upgrade path also runs during it (i.e.: ComfyUI) if the package is configured to do so.